### PR TITLE
Check for _.result in 'ensure' contract linting

### DIFF
--- a/deal/_runtime/_contracts.py
+++ b/deal/_runtime/_contracts.py
@@ -1,7 +1,9 @@
 from asyncio import iscoroutinefunction
 from functools import update_wrapper
 from inspect import isgeneratorfunction
-from typing import TYPE_CHECKING, Callable, Dict, Generic, List, Optional, Tuple, Type, TypeVar
+from typing import (
+    TYPE_CHECKING, Callable, Dict, Generic, List, Optional, Tuple, Type, TypeVar,
+)
 
 from .._exceptions import ContractError
 from .._state import state

--- a/deal/linter/_extractors/__init__.py
+++ b/deal/linter/_extractors/__init__.py
@@ -7,6 +7,7 @@ from .exceptions import get_exceptions
 from .imports import get_imports
 from .markers import get_markers
 from .pre import get_pre
+from .result import uses_result
 from .returns import get_returns, has_returns
 from .value import UNKNOWN, get_value
 
@@ -24,5 +25,6 @@ __all__ = [
     'get_returns',
     'get_value',
     'has_returns',
+    'uses_result',
     'UNKNOWN',
 ]

--- a/deal/linter/_extractors/result.py
+++ b/deal/linter/_extractors/result.py
@@ -1,5 +1,6 @@
 from itertools import chain
 import ast
+from typing import List
 import astroid
 from .common import traverse, get_name
 
@@ -46,20 +47,13 @@ def _has_result_arg(validator) -> bool:
 
 
 def _is_simple_validator(validator) -> bool:
+    arg_names: List[str]
     if isinstance(validator, ast.Lambda):
-        if len(validator.args.args) != 1:
-            return False
-        if validator.args.args[0].arg != '_':
-            return False
-        return True
-    if isinstance(validator, astroid.Lambda):
+        arg_names = [arg.arg for arg in validator.args.args]
+    elif isinstance(validator, astroid.Lambda):
         assert isinstance(validator.args, astroid.Arguments)
-        if len(validator.args.args) != 1:
-            return False
-        if validator.args.args[0].name != '_':
-            return False
-        return True
-    raise RuntimeError('unreachable')
+        arg_names = [arg.name for arg in validator.args.args]
+    return arg_names == ['_']
 
 
 def _simple_uses_result(validator) -> bool:

--- a/deal/linter/_extractors/result.py
+++ b/deal/linter/_extractors/result.py
@@ -1,0 +1,72 @@
+from itertools import chain
+import ast
+import astroid
+from .common import traverse, get_name
+
+
+def uses_result(validator) -> bool:
+    """Returns True if the validator uses `result` argument.
+
+    It may directly list `result` as the argument,
+    or it may be a simple validator and use `_.result` in the body.
+    """
+    if not isinstance(validator, (ast.Lambda, astroid.Lambda)):
+        return True
+    if _has_result_arg(validator):
+        return True
+    if _is_simple_validator(validator):
+        return _simple_uses_result(validator)
+    return False
+
+
+def _has_result_arg(validator) -> bool:
+    """Returns True if arguments list of the function has `result` argument.
+    """
+    if isinstance(validator, ast.Lambda):
+        args = chain(
+            validator.args.args,
+            validator.args.kwonlyargs,
+        )
+        for arg in args:
+            if arg.arg == 'result':
+                return True
+        return False
+    if isinstance(validator, astroid.Lambda):
+        assert isinstance(validator.args, astroid.Arguments)
+        args = chain(
+            validator.args.args,
+            validator.args.kwonlyargs,
+        )
+        for arg in args:
+            assert isinstance(arg, astroid.AssignName)
+            if arg.name == 'result':
+                return True
+        return False
+    raise RuntimeError('unreachable')
+
+
+def _is_simple_validator(validator) -> bool:
+    if isinstance(validator, ast.Lambda):
+        if len(validator.args.args) != 1:
+            return False
+        if validator.args.args[0].arg != '_':
+            return False
+        return True
+    if isinstance(validator, astroid.Lambda):
+        assert isinstance(validator.args, astroid.Arguments)
+        if len(validator.args.args) != 1:
+            return False
+        if validator.args.args[0].name != '_':
+            return False
+        return True
+    raise RuntimeError('unreachable')
+
+
+def _simple_uses_result(validator) -> bool:
+    """For simple validator, check if `_.result` is used in the body.
+    """
+    assert isinstance(validator, (ast.Lambda, astroid.Lambda))
+    for node in traverse(body=[validator.body]):
+        if get_name(node) == '_.result':
+            return True
+    return False

--- a/deal/linter/_extractors/result.py
+++ b/deal/linter/_extractors/result.py
@@ -1,8 +1,10 @@
-from itertools import chain
 import ast
+from itertools import chain
 from typing import List
+
 import astroid
-from .common import traverse, get_name
+
+from .common import get_name, traverse
 
 
 def uses_result(validator) -> bool:
@@ -50,7 +52,7 @@ def _is_simple_validator(validator) -> bool:
     arg_names: List[str]
     if isinstance(validator, ast.Lambda):
         arg_names = [arg.arg for arg in validator.args.args]
-    elif isinstance(validator, astroid.Lambda):
+    if isinstance(validator, astroid.Lambda):
         assert isinstance(validator.args, astroid.Arguments)
         arg_names = [arg.name for arg in validator.args.args]
     return arg_names == ['_']

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -118,6 +118,8 @@ class CheckEnsureArgs(FuncRule):
                 assert isinstance(arg, astroid.AssignName)
                 if arg.name == 'result':
                     return True
+                if arg.name == '_' and '_.result' in validator.body.as_string():
+                    return True
             return False
         return True
 

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -108,9 +108,9 @@ class CheckEnsureArgs(FuncRule):
                 if arg.arg == 'result':
                     return True
                 if arg.arg == '_' and any(
-                        hasattr(node, 'attr')
-                        and node.attr == 'result'  # type: ignore[attr-defined]
-                        for node in ast.walk(validator)
+                    hasattr(node, 'attr')
+                    and node.attr == 'result'  # type: ignore[attr-defined]
+                    for node in ast.walk(validator)
                 ):
                     return True
             return False

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -107,6 +107,13 @@ class CheckEnsureArgs(FuncRule):
             for arg in args:
                 if arg.arg == 'result':
                     return True
+                if arg.arg == '_':
+                    if any(
+                        hasattr(node, 'attr')
+                        and node.attr == 'result'
+                        for node in ast.walk(validator)
+                    ):
+                        return True
             return False
         if isinstance(validator, astroid.Lambda):
             assert isinstance(validator.args, astroid.Arguments)

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -107,13 +107,12 @@ class CheckEnsureArgs(FuncRule):
             for arg in args:
                 if arg.arg == 'result':
                     return True
-                if arg.arg == '_':
-                    if any(
+                if arg.arg == '_' and any(
                         hasattr(node, 'attr')
                         and node.attr == 'result'  # type: ignore[attr-defined]
                         for node in ast.walk(validator)
-                    ):
-                        return True
+                ):
+                    return True
             return False
         if isinstance(validator, astroid.Lambda):
             assert isinstance(validator.args, astroid.Arguments)

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -110,7 +110,7 @@ class CheckEnsureArgs(FuncRule):
                 if arg.arg == '_':
                     if any(
                         hasattr(node, 'attr')
-                        and node.attr == 'result'
+                        and node.attr == 'result'  # type: ignore[attr-defined]
                         for node in ast.walk(validator)
                     ):
                         return True

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -9,8 +9,7 @@ from ._contract import Category, Contract
 from ._error import Error
 from ._extractors import (
     UNKNOWN, get_asserts, get_example, get_exceptions, get_imports,
-    get_markers, get_pre, get_returns, get_value, has_returns,
-    uses_result,
+    get_markers, get_pre, get_returns, get_value, has_returns, uses_result,
 )
 from ._func import Func
 from ._stub import StubsManager

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -1,5 +1,4 @@
 import ast
-from itertools import chain
 from types import MappingProxyType
 from typing import Iterator, List, Optional, Set, Type, TypeVar, Union
 
@@ -11,6 +10,7 @@ from ._error import Error
 from ._extractors import (
     UNKNOWN, get_asserts, get_example, get_exceptions, get_imports,
     get_markers, get_pre, get_returns, get_value, has_returns,
+    uses_result,
 )
 from ._func import Func
 from ._stub import StubsManager
@@ -90,44 +90,13 @@ class CheckEnsureArgs(FuncRule):
 
     def _check(self, contract: Contract) -> Iterator[Error]:
         validator = contract.args[0]
-        if not self._result_found(validator):
+        if not uses_result(validator):
             yield Error(
                 code=self.code,
                 text=self.message,
                 row=validator.lineno,
                 col=validator.col_offset,
             )
-
-    def _result_found(self, validator) -> bool:
-        if isinstance(validator, ast.Lambda):
-            args = chain(
-                validator.args.args,
-                validator.args.kwonlyargs,
-            )
-            for arg in args:
-                if arg.arg == 'result':
-                    return True
-                if arg.arg == '_' and any(
-                    hasattr(node, 'attr')
-                    and node.attr == 'result'  # type: ignore[attr-defined]
-                    for node in ast.walk(validator)
-                ):
-                    return True
-            return False
-        if isinstance(validator, astroid.Lambda):
-            assert isinstance(validator.args, astroid.Arguments)
-            args = chain(
-                validator.args.args,
-                validator.args.kwonlyargs,
-            )
-            for arg in args:
-                assert isinstance(arg, astroid.AssignName)
-                if arg.name == 'result':
-                    return True
-                if arg.name == '_' and '_.result' in validator.body.as_string():
-                    return True
-            return False
-        return True
 
 
 @register

--- a/tests/test_linter/test_extractors/test_result.py
+++ b/tests/test_linter/test_extractors/test_result.py
@@ -1,0 +1,40 @@
+import ast
+
+import astroid
+import pytest
+
+from deal.linter._extractors import uses_result
+
+
+@pytest.mark.parametrize('given, expected', [
+    # positive
+    ('lambda a, result: 0', True),
+    ('lambda a, result: 0', True),
+    ('lambda a, *, result: 0', True),
+    ('lambda *a, result: 0', True),
+    ('lambda *a, result=None: 0', True),
+    ('lambda _: _.result', True),
+    ('lambda _: len(_.result) == _.length', True),
+
+    # non-lambdas are allowed
+    ('unknown', True),
+    ('sum', True),
+
+    # negative
+    ('lambda _: 0', False),
+    ('lambda _: _', False),
+    ('lambda _: _.other', False),
+    ('lambda a: 0', False),
+    ('lambda a, res: 0', False),
+    ('lambda a, *, res: 0', False),
+])
+def test_uses_result(given: str, expected: bool):
+    tree = astroid.parse(given)
+    print(tree.repr_tree())
+    validator = tree.body[0].value
+    assert uses_result(validator) is expected
+
+    tree = ast.parse(given)
+    print(ast.dump(tree))
+    validator = tree.body[0].value  # type: ignore[attr-defined]
+    assert uses_result(validator) is expected

--- a/tests/test_linter/test_rules.py
+++ b/tests/test_linter/test_rules.py
@@ -487,23 +487,9 @@ def test_check_example_ensure():
 
 
 @pytest.mark.parametrize('expr, should_pass', [
-    ('lambda a, result: 0', True),
-    ('lambda a, result: 0', True),
-    ('lambda a, *, result: 0', True),
-    ('lambda *a, result: 0', True),
-    ('lambda *a, result=None: 0', True),
-    ('lambda _: _.result', True),
-    ('lambda _: len(_.result) == _.length', True),
-
     ('unknown', True),
-    ('sum', True),
-
-    ('lambda _: 0', False),
-    ('lambda _: _', False),
-    ('lambda _: _.other', False),
+    ('lambda a, result: 0', True),
     ('lambda a: 0', False),
-    ('lambda a, res: 0', False),
-    ('lambda a, *, res: 0', False),
 ])
 def test_ensure_args(expr, should_pass):
     checker = CheckEnsureArgs()

--- a/tests/test_linter/test_rules.py
+++ b/tests/test_linter/test_rules.py
@@ -492,10 +492,15 @@ def test_check_example_ensure():
     ('lambda a, *, result: 0', True),
     ('lambda *a, result: 0', True),
     ('lambda *a, result=None: 0', True),
+    ('lambda _: _.result', True),
+    ('lambda _: len(_.result) == _.length', True),
 
     ('unknown', True),
     ('sum', True),
 
+    ('lambda _: 0', False),
+    ('lambda _: _', False),
+    ('lambda _: _.other', False),
     ('lambda a: 0', False),
     ('lambda a, res: 0', False),
     ('lambda a, *, res: 0', False),


### PR DESCRIPTION
Previously, using `_` in a `@deal.ensure` contract validator would lead to this error:

```console
$ python3 -m deal lint
dumbpw/pwgen.py
  32:4 DEAL002 ensure contract must have `result` arg
    lambda _: len(_.result) == _.length,
    ^
```

This change fixes that false positive by detecting when the arg name is `_` and passing the lint check if `_.result` is anywhere in the validator body.