### PR TITLE
Improve linter behavior for `assert`

### DIFF
--- a/deal/_cached_property.py
+++ b/deal/_cached_property.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Generic, Optional, Type, TypeVar, overload
+from typing import Any, Callable, Generic, Optional, TypeVar, overload
 
 
 T = TypeVar('T')
@@ -9,11 +9,11 @@ class cached_property(Generic[T]):  # noqa: N801
         self.func = func
 
     @overload
-    def __get__(self, instance: None, owner: Optional[Type[Any]] = ...) -> 'cached_property[T]':
+    def __get__(self, instance: None, owner: Optional[type] = ...) -> 'cached_property[T]':
         pass
 
     @overload
-    def __get__(self, instance, owner: Optional[Type[Any]] = ...) -> T:
+    def __get__(self, instance, owner: Optional[type] = ...) -> T:
         pass
 
     def __get__(self, obj, cls):

--- a/deal/_cli/_main.py
+++ b/deal/_cli/_main.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
@@ -29,8 +30,8 @@ def get_commands() -> CommandsType:
 
 def main(
     argv: Sequence[str], *,
-    commands: CommandsType = None,
-    root: Path = None,
+    commands: Optional[CommandsType] = None,
+    root: Optional[Path] = None,
     stream: TextIO = sys.stdout,
 ) -> int:
     if commands is None:

--- a/deal/_cli/_main.py
+++ b/deal/_cli/_main.py
@@ -1,8 +1,7 @@
-from typing import Optional
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Mapping, Sequence, TextIO, Type
+from typing import Mapping, Optional, Sequence, TextIO, Type
 
 from ._base import Command
 

--- a/deal/_exceptions.py
+++ b/deal/_exceptions.py
@@ -53,7 +53,7 @@ class ContractError(AssertionError):
         message: str = '',
         errors=None,
         validator=None,
-        params: Dict[str, Any] = None,
+        params: Optional[Dict[str, Any]] = None,
         origin: Optional[object] = None,
     ) -> None:
         self.message = message

--- a/deal/_imports.py
+++ b/deal/_imports.py
@@ -33,7 +33,7 @@ class DealFinder(PathFinder):
 class DealLoader:
     __slots__ = ('_loader', )
 
-    def __init__(self, loader):
+    def __init__(self, loader) -> None:
         self._loader = loader
 
     def __getattr__(self, name: str):

--- a/deal/_runtime/_contracts.py
+++ b/deal/_runtime/_contracts.py
@@ -41,7 +41,7 @@ class Contracts(Generic[F]):
     reasons: List['ReasonValidator']
     patcher: Optional['HasPatcher']
 
-    def __init__(self, func: F):
+    def __init__(self, func: F) -> None:
         self.func = func
         self.pres = []
         self.posts = []

--- a/deal/_runtime/_decorators.py
+++ b/deal/_runtime/_decorators.py
@@ -20,8 +20,8 @@ TF = TypeVar('TF', bound=Union[Callable, type])
 def pre(
     validator,
     *,
-    message: str = None,
-    exception: ExceptionType = None,
+    message: Optional[str] = None,
+    exception: Optional[ExceptionType] = None,
 ) -> Callable[[C], C]:
     """Decorator implementing precondition [value] contract.
 
@@ -65,8 +65,8 @@ def pre(
 def post(
     validator,
     *,
-    message: str = None,
-    exception: ExceptionType = None,
+    message: Optional[str] = None,
+    exception: Optional[ExceptionType] = None,
 ) -> Callable[[C], C]:
     """Decorator implementing postcondition [value] contract.
 
@@ -110,8 +110,8 @@ def post(
 def ensure(
     validator,
     *,
-    message: str = None,
-    exception: ExceptionType = None,
+    message: Optional[str] = None,
+    exception: Optional[ExceptionType] = None,
 ) -> Callable[[C], C]:
     """Decorator implementing postcondition [value] contract.
 
@@ -157,8 +157,8 @@ def ensure(
 
 def raises(
     *exceptions: Type[Exception],
-    message: str = None,
-    exception: ExceptionType = None,
+    message: Optional[str] = None,
+    exception: Optional[ExceptionType] = None,
 ) -> Callable[[C], C]:
     """Decorator listing the exceptions which the function can raise.
 
@@ -206,8 +206,8 @@ def raises(
 
 def has(
     *markers: str,
-    message: str = None,
-    exception: ExceptionType = None,
+    message: Optional[str] = None,
+    exception: Optional[ExceptionType] = None,
 ) -> Callable[[C], C]:
     """Decorator controlling [side-effects] of the function.
 
@@ -252,8 +252,8 @@ def reason(
     event: Type[Exception],
     validator,
     *,
-    message: str = None,
-    exception: ExceptionType = None,
+    message: Optional[str] = None,
+    exception: Optional[ExceptionType] = None,
 ) -> Callable[[C], C]:
     """
     Decorator implementing [exception] contract.
@@ -306,8 +306,8 @@ def reason(
 def inv(
     validator,
     *,
-    message: str = None,
-    exception: ExceptionType = None,
+    message: Optional[str] = None,
+    exception: Optional[ExceptionType] = None,
 ) -> Callable[[T], T]:
     """
     Decorator implementing invariant [value] contract.
@@ -397,8 +397,8 @@ def example(validator: Callable[[], bool]) -> Callable[[C], C]:
 @overload
 def safe(
     *,
-    message: str = None,
-    exception: ExceptionType = None,
+    message: Optional[str] = None,
+    exception: Optional[ExceptionType] = None,
 ) -> Callable[[C], C]:
     pass
 

--- a/deal/_runtime/_dispatch.py
+++ b/deal/_runtime/_dispatch.py
@@ -17,7 +17,7 @@ class Dispatch(Generic[F]):
     _functions: List[F]
     __call__: F
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._functions = []
 
     @classmethod

--- a/deal/_runtime/_has_patcher.py
+++ b/deal/_runtime/_has_patcher.py
@@ -1,8 +1,7 @@
-from typing import Optional
 import socket
 import sys
 from io import StringIO
-from typing import FrozenSet, Type
+from typing import FrozenSet, Optional, Type
 
 from .._exceptions import MarkerError, OfflineContractError, SilentContractError
 from .._types import ExceptionType

--- a/deal/_runtime/_has_patcher.py
+++ b/deal/_runtime/_has_patcher.py
@@ -1,7 +1,7 @@
 import socket
 import sys
 from io import StringIO
-from typing import FrozenSet, Optional, Type
+from typing import FrozenSet, Iterable, Optional, Type
 
 from .._exceptions import MarkerError, OfflineContractError, SilentContractError
 from .._types import ExceptionType
@@ -70,7 +70,12 @@ class HasPatcher:
     )
     markers: FrozenSet[str]
 
-    def __init__(self, markers, message: Optional[str] = None, exception: Optional[ExceptionType] = None) -> None:
+    def __init__(
+        self,
+        markers: Iterable[str],
+        message: Optional[str] = None,
+        exception: Optional[ExceptionType] = None,
+    ) -> None:
         self.markers = frozenset(markers)
         self.message = message
         self.exception = exception or MarkerError

--- a/deal/_runtime/_has_patcher.py
+++ b/deal/_runtime/_has_patcher.py
@@ -42,7 +42,7 @@ NON_IO_MARKERS = frozenset({
 class PatchedStringIO(StringIO):
     __slots__ = ('exception',)
 
-    def __init__(self, exception: ExceptionType):
+    def __init__(self, exception: ExceptionType) -> None:
         self.exception = exception
 
     def write(self, *args, **kwargs):
@@ -52,7 +52,7 @@ class PatchedStringIO(StringIO):
 class PatchedSocket:
     __slots__ = ('exception',)
 
-    def __init__(self, exception: ExceptionType):
+    def __init__(self, exception: ExceptionType) -> None:
         self.exception = exception
 
     def __call__(self, *args, **kwargs):
@@ -70,7 +70,7 @@ class HasPatcher:
     )
     markers: FrozenSet[str]
 
-    def __init__(self, markers, message: str = None, exception: ExceptionType = None):
+    def __init__(self, markers, message: str = None, exception: ExceptionType = None) -> None:
         self.markers = frozenset(markers)
         self.message = message
         self.exception = exception or MarkerError

--- a/deal/_runtime/_has_patcher.py
+++ b/deal/_runtime/_has_patcher.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import socket
 import sys
 from io import StringIO
@@ -70,7 +71,7 @@ class HasPatcher:
     )
     markers: FrozenSet[str]
 
-    def __init__(self, markers, message: str = None, exception: ExceptionType = None) -> None:
+    def __init__(self, markers, message: Optional[str] = None, exception: Optional[ExceptionType] = None) -> None:
         self.markers = frozenset(markers)
         self.message = message
         self.exception = exception or MarkerError

--- a/deal/_runtime/_validators.py
+++ b/deal/_runtime/_validators.py
@@ -66,7 +66,7 @@ class Validator:
         validator, *,
         message: str = None,
         exception: ExceptionType,
-    ):
+    ) -> None:
         self.validate = self._init
         self.raw_validator = validator
         self.message = message
@@ -201,7 +201,7 @@ class RaisesValidator(Validator):
     __slots__ = ('exceptions', )
     exceptions: Tuple[Type[Exception]]
 
-    def __init__(self, exceptions, exception, message):
+    def __init__(self, exceptions, exception, message) -> None:
         self.exceptions = exceptions
         self.validator = None
         super().__init__(validator=None, message=message, exception=exception)
@@ -226,7 +226,7 @@ class ReasonValidator(Validator):
     __slots__ = ('event', )
     event: Type[Exception]
 
-    def __init__(self, event, **kwargs):
+    def __init__(self, event, **kwargs) -> None:
         self.event = event
         super().__init__(**kwargs)
 

--- a/deal/_runtime/_validators.py
+++ b/deal/_runtime/_validators.py
@@ -64,7 +64,7 @@ class Validator:
     def __init__(
         self,
         validator, *,
-        message: str = None,
+        message: Optional[str] = None,
         exception: ExceptionType,
     ) -> None:
         self.validate = self._init
@@ -96,7 +96,7 @@ class Validator:
 
         return validator
 
-    def _exception(self, *, message: str = None, errors=None, params=None) -> Exception:
+    def _exception(self, *, message: Optional[str] = None, errors=None, params=None) -> Exception:
         exception = self.exception
         if isinstance(exception, Exception):
             if not message and exception.args:

--- a/deal/_state.py
+++ b/deal/_state.py
@@ -10,7 +10,7 @@ class _State:
     debug: bool
     color: bool
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.reset()
 
     def reset(self) -> None:

--- a/deal/_testing.py
+++ b/deal/_testing.py
@@ -350,7 +350,7 @@ class cases:  # noqa: N
     @staticmethod
     def _impersonate(wrapper: F, wrapped: F) -> F:
         if not hasattr(wrapped, '__code__'):
-            def wrapped(case):
+            def wrapped(case) -> None:
                 pass
         wrapper = proxies(wrapped)(wrapper)
         if wrapper.__name__ == '<lambda>':

--- a/deal/_testing.py
+++ b/deal/_testing.py
@@ -92,7 +92,7 @@ class cases:  # noqa: N
         self,
         func: typing.Callable, *,
         count: int = 50,
-        kwargs: typing.Dict[str, typing.Any] = None,
+        kwargs: typing.Optional[typing.Dict[str, typing.Any]] = None,
         check_types: bool = True,
         settings: typing.Optional[hypothesis.settings] = None,
         seed: typing.Optional[int] = None,

--- a/deal/introspection/_wrappers.py
+++ b/deal/introspection/_wrappers.py
@@ -12,7 +12,7 @@ class Contract:
     __slots__ = ('_wrapped',)
     _wrapped: Validator
 
-    def __init__(self, wrapped):
+    def __init__(self, wrapped) -> None:
         self._wrapped = wrapped
 
     @property
@@ -116,7 +116,7 @@ class Has(Contract):
     __slots__ = ('_patcher',)
     _patcher: HasPatcher
 
-    def __init__(self, wrapped):
+    def __init__(self, wrapped) -> None:
         self._patcher = wrapped
 
     @property

--- a/deal/linter/_checker.py
+++ b/deal/linter/_checker.py
@@ -17,7 +17,7 @@ class Checker:
     version = __version__
     _rules = rules
 
-    def __init__(self, tree: ast.Module, file_tokens=None, filename: str = 'stdin'):
+    def __init__(self, tree: ast.Module, file_tokens=None, filename: str = 'stdin') -> None:
         self._tree = tree
         self._filename = filename
 

--- a/deal/linter/_contract.py
+++ b/deal/linter/_contract.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import ast
 import builtins
 import enum
@@ -43,7 +44,7 @@ class Contract:
         args: Iterable,
         category: Category,
         func_args: ast.arguments,
-        context: Dict[str, ast.stmt] = None,
+        context: Optional[Dict[str, ast.stmt]] = None,
         line: int = 0,
     ) -> None:
         self.args = tuple(args)

--- a/deal/linter/_contract.py
+++ b/deal/linter/_contract.py
@@ -1,10 +1,9 @@
-from typing import Optional
 import ast
 import builtins
 import enum
 from copy import copy
 from pathlib import Path
-from typing import Dict, FrozenSet, Iterable, List, Type, Union
+from typing import Dict, FrozenSet, Iterable, List, Optional, Type, Union
 
 import astroid
 

--- a/deal/linter/_contract.py
+++ b/deal/linter/_contract.py
@@ -45,7 +45,7 @@ class Contract:
         func_args: ast.arguments,
         context: Dict[str, ast.stmt] = None,
         line: int = 0,
-    ):
+    ) -> None:
         self.args = tuple(args)
         self.category = category
         self.func_args = func_args

--- a/deal/linter/_error.py
+++ b/deal/linter/_error.py
@@ -7,7 +7,7 @@ ERROR_FORMAT = 'DEAL{code:03d}'
 class Error:
     __slots__ = ('row', 'col', 'code', 'text', 'value')
 
-    def __init__(self, *, row: int, col: int, code: int, text: str, value: str = None):
+    def __init__(self, *, row: int, col: int, code: int, text: str, value: str = None) -> None:
         self.row = row
         self.col = col
         self.code = code

--- a/deal/linter/_error.py
+++ b/deal/linter/_error.py
@@ -7,7 +7,14 @@ ERROR_FORMAT = 'DEAL{code:03d}'
 class Error:
     __slots__ = ('row', 'col', 'code', 'text', 'value')
 
-    def __init__(self, *, row: int, col: int, code: int, text: str, value: typing.Optional[str] = None) -> None:
+    def __init__(
+        self, *,
+        row: int,
+        col: int,
+        code: int,
+        text: str,
+        value: typing.Optional[str] = None,
+    ) -> None:
         self.row = row
         self.col = col
         self.code = code

--- a/deal/linter/_error.py
+++ b/deal/linter/_error.py
@@ -7,7 +7,7 @@ ERROR_FORMAT = 'DEAL{code:03d}'
 class Error:
     __slots__ = ('row', 'col', 'code', 'text', 'value')
 
-    def __init__(self, *, row: int, col: int, code: int, text: str, value: str = None) -> None:
+    def __init__(self, *, row: int, col: int, code: int, text: str, value: typing.Optional[str] = None) -> None:
         self.row = row
         self.col = col
         self.code = code
@@ -37,5 +37,5 @@ class Error:
         name = type(self).__name__
         return f'{name}(row={self.row}, col={self.col}, code={self.code})'
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.row, self.col, self.code))

--- a/deal/linter/_extractors/asserts.py
+++ b/deal/linter/_extractors/asserts.py
@@ -1,4 +1,6 @@
-from typing import Optional
+import ast
+import astroid
+from typing import Optional, Union
 
 from .common import TOKENS, Extractor, Token
 from .value import UNKNOWN, get_value
@@ -8,8 +10,8 @@ get_asserts = Extractor()
 
 
 @get_asserts.register(*TOKENS.ASSERT)
-def handle_assert(expr) -> Optional[Token]:
-    value = get_value(expr=expr.test)
+def handle_assert(expr: Union[ast.Assert, astroid.Assert]) -> Optional[Token]:
+    value = get_value(expr=expr.test, allow_inference=False)
     if value is UNKNOWN:
         return None
     if value:

--- a/deal/linter/_extractors/asserts.py
+++ b/deal/linter/_extractors/asserts.py
@@ -1,6 +1,7 @@
 import ast
-import astroid
 from typing import Optional, Union
+
+import astroid
 
 from .common import TOKENS, Extractor, Token
 from .value import UNKNOWN, get_value

--- a/deal/linter/_extractors/common.py
+++ b/deal/linter/_extractors/common.py
@@ -154,7 +154,7 @@ class Extractor:
     __slots__ = ('handlers', )
     handlers: Dict[type, Handler]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.handlers = dict()
 
     def _register(self, types: Tuple[type], handler: Handler) -> Handler:

--- a/deal/linter/_extractors/common.py
+++ b/deal/linter/_extractors/common.py
@@ -32,9 +32,13 @@ class TOKENS:
     YIELD: N[ast.Yield] = (ast.Yield, astroid.Yield)
 
 
+DEFAULT_LINE = 0
+DEFAULT_COL = 1
+
+
 class Token(NamedTuple):
-    line: int = 0
-    col: int = 1
+    line: int = DEFAULT_LINE
+    col: int = DEFAULT_COL
     value: Optional[object] = None
     marker: Optional[str] = None  # marker name or error message
 
@@ -190,8 +194,8 @@ class Extractor:
 
     @staticmethod
     def _ensure_node_info(token: Token, expr: Union[ast.AST, astroid.NodeNG]) -> Token:
-        if token.line == 0:
+        if token.line == DEFAULT_LINE:
             token = token._replace(line=expr.lineno)
-        if token.col == 1:
+        if token.col == DEFAULT_COL:
             token = token._replace(col=expr.col_offset)
         return token

--- a/deal/linter/_extractors/common.py
+++ b/deal/linter/_extractors/common.py
@@ -111,7 +111,7 @@ def get_full_name(expr: astroid.NodeNG) -> Tuple[str, str]:
 def infer(expr) -> Tuple[astroid.NodeNG, ...]:
     if not isinstance(expr, astroid.NodeNG):
         return tuple()
-    with suppress(astroid.exceptions.InferenceError, RecursionError):
+    with suppress(astroid.InferenceError, RecursionError):
         guesses = expr.infer()
         if guesses is astroid.Uninferable:  # pragma: no cover
             return tuple()
@@ -165,7 +165,7 @@ class Extractor:
     def register(self, *types):
         return partial(self._register, types)
 
-    def handle(self, expr, **kwargs):
+    def handle(self, expr, **kwargs) -> Iterator[Token]:
         handler = self.handlers.get(type(expr))
         if handler is None:
             return

--- a/deal/linter/_extractors/common.py
+++ b/deal/linter/_extractors/common.py
@@ -3,7 +3,9 @@ from collections import deque
 from contextlib import suppress
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, Iterator, List, NamedTuple, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Callable, Dict, Iterator, List, NamedTuple, Optional, Tuple, Type, TypeVar, Union,
+)
 
 import astroid
 

--- a/deal/linter/_extractors/exceptions.py
+++ b/deal/linter/_extractors/exceptions.py
@@ -59,7 +59,7 @@ def handle_bin_op(expr: Union[ast.BinOp, astroid.BinOp], **kwargs) -> Optional[T
 def handle_call(
     expr: Union[ast.Call, astroid.Call],
     dive: bool = True,
-    stubs: StubsManager = None,
+    stubs: Optional[StubsManager] = None,
 ) -> Iterator[Token]:
     token_info: Dict[str, Any] = dict(line=expr.lineno, col=expr.col_offset)
     # exit()

--- a/deal/linter/_extractors/markers.py
+++ b/deal/linter/_extractors/markers.py
@@ -116,7 +116,6 @@ def handle_astroid_import_from(expr: astroid.ImportFrom, **kwargs) -> Optional[T
 
 @get_markers.register(*TOKENS.CALL)
 def handle_call(expr, dive: bool = True, stubs: Optional[StubsManager] = None) -> Iterator[Token]:
-    token_info = dict(line=expr.lineno, col=expr.col_offset)
     name = get_name(expr.func)
     if name is None:
         return
@@ -127,41 +126,41 @@ def handle_call(expr, dive: bool = True, stubs: Optional[StubsManager] = None) -
         yield token
         return
     if name.startswith('sys.stdout'):
-        yield Token(marker='stdout', value='sys.stdout.', **token_info)
+        yield Token(marker='stdout', value='sys.stdout.')
         return
     if name.startswith('sys.stderr'):
-        yield Token(marker='stderr', value='sys.stderr.', **token_info)
+        yield Token(marker='stderr', value='sys.stderr.')
         return
     if name.startswith('sys.stdin'):
-        yield Token(marker='stdin', value='sys.stdin.', **token_info)
+        yield Token(marker='stdin', value='sys.stdin.')
         return
     if name == 'input':
-        yield Token(marker='stdin', value='input', **token_info)
+        yield Token(marker='stdin', value='input')
         return
 
     # random, import,
     if name == '__import__':
-        yield Token(marker='import', **token_info)
+        yield Token(marker='import')
         return
     if _is_random(expr=expr, name=name):
-        yield Token(marker='random', value=name, **token_info)
+        yield Token(marker='random', value=name)
         return
     if _is_syscall(expr=expr, name=name):
-        yield Token(marker='syscall', value=name, **token_info)
+        yield Token(marker='syscall', value=name)
         return
     if _is_time(expr=expr, name=name):
-        yield Token(marker='time', value=name, **token_info)
+        yield Token(marker='time', value=name)
         return
 
     # read and write
     if name == 'open':
         if _is_open_to_write(expr):
-            yield Token(marker='write', value='open', **token_info)
+            yield Token(marker='write', value='open')
         else:
-            yield Token(marker='read', value='open', **token_info)
+            yield Token(marker='read', value='open')
         return
     if _is_pathlib_write(expr):
-        yield Token(marker='write', value='Path.open', **token_info)
+        yield Token(marker='write', value='Path.open')
         return
 
     yield from _infer_markers(expr=expr, dive=dive, stubs=stubs)

--- a/deal/linter/_extractors/markers.py
+++ b/deal/linter/_extractors/markers.py
@@ -115,7 +115,7 @@ def handle_astroid_import_from(expr: astroid.ImportFrom, **kwargs) -> Optional[T
 
 
 @get_markers.register(*TOKENS.CALL)
-def handle_call(expr, dive: bool = True, stubs: StubsManager = None) -> Iterator[Token]:
+def handle_call(expr, dive: bool = True, stubs: Optional[StubsManager] = None) -> Iterator[Token]:
     token_info = dict(line=expr.lineno, col=expr.col_offset)
     name = get_name(expr.func)
     if name is None:
@@ -167,7 +167,7 @@ def handle_call(expr, dive: bool = True, stubs: StubsManager = None) -> Iterator
     yield from _infer_markers(expr=expr, dive=dive, stubs=stubs)
 
 
-def _infer_markers(expr, dive: bool, stubs: StubsManager = None) -> Iterator[Token]:
+def _infer_markers(expr, dive: bool, stubs: Optional[StubsManager] = None) -> Iterator[Token]:
     inferred = infer(expr=expr.func)
     stubs_found = False
     if type(expr) is astroid.Call and stubs is not None:

--- a/deal/linter/_extractors/pre.py
+++ b/deal/linter/_extractors/pre.py
@@ -1,6 +1,5 @@
-from typing import Optional
 import ast
-from typing import Any, Dict, Iterator, Sequence
+from typing import Any, Dict, Iterator, Optional, Sequence
 
 import astroid
 

--- a/deal/linter/_extractors/pre.py
+++ b/deal/linter/_extractors/pre.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import ast
 from typing import Any, Dict, Iterator, Sequence
 
@@ -12,7 +13,7 @@ get_pre = Extractor()
 
 
 @get_pre.register(astroid.Call)
-def handle_call(expr: astroid.Call, context: Dict[str, ast.stmt] = None) -> Iterator[Token]:
+def handle_call(expr: astroid.Call, context: Optional[Dict[str, ast.stmt]] = None) -> Iterator[Token]:
     from .._contract import Category, Contract
 
     args = []

--- a/deal/linter/_extractors/value.py
+++ b/deal/linter/_extractors/value.py
@@ -1,35 +1,33 @@
 import ast
 from contextlib import suppress
+from typing import Union
 
 import astroid
 
-from .common import Extractor, infer
+from .common import infer
 
 
-inner_extractor = Extractor()
 UNKNOWN = object()
+Node = Union[ast.AST, astroid.NodeNG]
 
 
-def get_value(expr):
+def get_value(expr: Node, allow_inference: bool = True) -> object:
     if isinstance(expr, ast.AST):
         with suppress(ValueError, SyntaxError):
             return ast.literal_eval(expr)
 
-    if isinstance(expr, astroid.node_classes.NodeNG):
+    if isinstance(expr, astroid.NodeNG):
         # AttributeError: 'AsStringVisitor3' object has no attribute 'visit_unknown'
         with suppress(AttributeError):  # pragma: no cover
             renderred = expr.as_string()
             with suppress(ValueError, SyntaxError):
                 return ast.literal_eval(renderred)
 
-    handler = inner_extractor.handlers.get(type(expr))
-    if handler:
-        value = handler(expr=expr)
-        if value is not UNKNOWN:
-            return value
+    value = _parse_collections(expr=expr)
+    if value is not UNKNOWN:
+        return value
 
-    # astroid inference
-    if hasattr(expr, 'infer'):
+    if allow_inference:
         for parent_expr in infer(expr=expr):
             if parent_expr == expr:  # avoid recursion
                 continue
@@ -39,8 +37,10 @@ def get_value(expr):
     return UNKNOWN
 
 
-@inner_extractor.register(astroid.List, astroid.Set, astroid.Tuple)
-def handle_collections(expr):
+def _parse_collections(expr: Node) -> object:
+    if not isinstance(expr, (astroid.List, astroid.Set, astroid.Tuple)):
+        return UNKNOWN
+
     result = []
     for element_expr in expr.elts:
         value = get_value(expr=element_expr)

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -53,7 +53,7 @@ class ModuleRule(Rule):
 class FuncRule(Rule):
     __slots__ = ()
 
-    def __call__(self, func: Func, stubs: StubsManager = None) -> Iterator[Error]:
+    def __call__(self, func: Func, stubs: Optional[StubsManager] = None) -> Iterator[Error]:
         raise NotImplementedError
 
 
@@ -81,7 +81,7 @@ class CheckEnsureArgs(FuncRule):
     code = 2
     message = 'ensure contract must have `result` arg'
 
-    def __call__(self, func: Func, stubs: StubsManager = None) -> Iterator[Error]:
+    def __call__(self, func: Func, stubs: Optional[StubsManager] = None) -> Iterator[Error]:
         for contract in func.contracts:
             if contract.category != Category.ENSURE:
                 continue
@@ -104,7 +104,7 @@ class CheckPre(FuncRule):
     code = 11
     message = 'pre contract error'
 
-    def __call__(self, func: Func, stubs: StubsManager = None) -> Iterator[Error]:
+    def __call__(self, func: Func, stubs: Optional[StubsManager] = None) -> Iterator[Error]:
         # We test only contracted functions because of poor performance.
         # Inferring every called function in the whole project
         # is a really expensive operation.
@@ -127,7 +127,7 @@ class CheckReturns(FuncRule):
     code = 12
     message = 'post contract error'
 
-    def __call__(self, func: Func, stubs: StubsManager = None) -> Iterator[Error]:
+    def __call__(self, func: Func, stubs: Optional[StubsManager] = None) -> Iterator[Error]:
         for contract in func.contracts:
             if contract.category != Category.POST:
                 continue
@@ -153,7 +153,7 @@ class CheckExamples(FuncRule):
     code = 13
     message = 'example violates contract'
 
-    def __call__(self, func: Func, stubs: StubsManager = None) -> Iterator[Error]:
+    def __call__(self, func: Func, stubs: Optional[StubsManager] = None) -> Iterator[Error]:
         for contract in func.contracts:
             if contract.category != Category.EXAMPLE:
                 continue
@@ -214,7 +214,7 @@ class CheckRaises(FuncRule):
     code = 21
     message = 'raises contract error'
 
-    def __call__(self, func: Func, stubs: StubsManager = None) -> Iterator[Error]:
+    def __call__(self, func: Func, stubs: Optional[StubsManager] = None) -> Iterator[Error]:
         cats = {Category.RAISES, Category.SAFE, Category.PURE}
         declared: Exceptions = []
         check = False
@@ -256,7 +256,7 @@ class CheckAsserts(FuncRule):
     code = 31
     message = 'assert error'
 
-    def __call__(self, func: Func, stubs: StubsManager = None) -> Iterator[Error]:
+    def __call__(self, func: Func, stubs: Optional[StubsManager] = None) -> Iterator[Error]:
         # do not validate asserts in tests
         if func.name.startswith('test_'):
             return
@@ -293,7 +293,7 @@ class CheckMarkers(FuncRule):
         'time': 56,
     })
 
-    def __call__(self, func: Func, stubs: StubsManager = None) -> Iterator[Error]:
+    def __call__(self, func: Func, stubs: Optional[StubsManager] = None) -> Iterator[Error]:
         for contract in func.contracts:
             markers: Optional[Set[str]] = None
             if contract.category == Category.HAS:

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -297,10 +297,14 @@ class CheckMarkers(FuncRule):
         for contract in func.contracts:
             markers: Optional[Set[str]] = None
             if contract.category == Category.HAS:
-                markers = {get_value(arg) for arg in contract.args}
+                markers = set()
+                for arg in contract.args:
+                    value = get_value(arg)
+                    if isinstance(value, str):
+                        markers.add(value)
             elif contract.category == Category.PURE:
                 markers = set()
-            if markers is None:
+            if markers is None:  # this is needed to fix coverage quirks
                 continue
             yield from self.get_undeclared(func=func, markers=markers)
             return

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -216,7 +216,7 @@ class CheckRaises(FuncRule):
 
     def __call__(self, func: Func, stubs: Optional[StubsManager] = None) -> Iterator[Error]:
         cats = {Category.RAISES, Category.SAFE, Category.PURE}
-        declared: Exceptions = []
+        declared: Exceptions = [AssertionError]
         check = False
         for contract in func.contracts:
             if contract.category not in cats:

--- a/deal/linter/_stub.py
+++ b/deal/linter/_stub.py
@@ -55,14 +55,14 @@ class StubsManager:
 
     default_paths = (ROOT, CPYTHON_ROOT)
 
-    def __init__(self, paths: Sequence[Path] = None) -> None:
+    def __init__(self, paths: Optional[Sequence[Path]] = None) -> None:
         self._modules = dict()
         if paths is None:
             self.paths = self.default_paths
         else:
             self.paths = tuple(paths)
 
-    def read(self, *, path: Path, module_name: str = None) -> StubFile:
+    def read(self, *, path: Path, module_name: Optional[str] = None) -> StubFile:
         if path.suffix == '.py':
             path = path.with_suffix(EXTENSION)
         if path.suffix != EXTENSION:
@@ -149,7 +149,7 @@ def _get_funcs_from_expr(expr, prefix: str = '') -> Iterator[PseudoFunc]:
             yield from _get_funcs_from_expr(expr=subexpr, prefix=name)
 
 
-def generate_stub(*, path: Path, stubs: StubsManager = None) -> Path:
+def generate_stub(*, path: Path, stubs: Optional[StubsManager] = None) -> Path:
     from ._extractors import get_exceptions, get_markers
 
     if path.suffix != '.py':

--- a/deal/linter/_stub.py
+++ b/deal/linter/_stub.py
@@ -132,7 +132,7 @@ def _get_funcs(*, path: Path) -> Iterator[PseudoFunc]:
         yield from _get_funcs_from_expr(expr=expr)
 
 
-def _get_funcs_from_expr(expr, prefix='') -> Iterator[PseudoFunc]:
+def _get_funcs_from_expr(expr, prefix: str = '') -> Iterator[PseudoFunc]:
     name = getattr(expr, 'name', '')
     if prefix:
         name = prefix + '.' + name

--- a/deal/linter/_stub.py
+++ b/deal/linter/_stub.py
@@ -55,7 +55,7 @@ class StubsManager:
 
     default_paths = (ROOT, CPYTHON_ROOT)
 
-    def __init__(self, paths: Sequence[Path] = None):
+    def __init__(self, paths: Sequence[Path] = None) -> None:
         self._modules = dict()
         if paths is None:
             self.paths = self.default_paths

--- a/deal/linter/_transformer.py
+++ b/deal/linter/_transformer.py
@@ -180,7 +180,10 @@ class Transformer(NamedTuple):
         for contract in func.contracts:
             if contract.category not in cats:
                 continue
-            declared.extend(get_value(arg) for arg in contract.args)
+            for arg in contract.args:
+                value = get_value(arg)
+                if isinstance(value, str):
+                    declared.append(value)
 
         # collect undeclared markers
         markers: Set[str] = set()

--- a/deal/mypy.py
+++ b/deal/mypy.py
@@ -24,7 +24,7 @@ perf: DefaultDict[str, List[float]] = defaultdict(list)
 TRACK_PERF = os.getenv('DEAL_TRACK_PERF')
 
 
-def show_perf():
+def show_perf() -> None:
     overall = .0
     for name, times in sorted(perf.items()):
         total = sum(times)

--- a/tests/test_cli/test_test.py
+++ b/tests/test_cli/test_test.py
@@ -158,7 +158,7 @@ def test_format_coverage_100(cov_l, all_l, exp):
 
 
 def test_run_cases_ok():
-    def func():
+    def func() -> int:
         return 123
 
     case = TestCase(

--- a/tests/test_linter/test_extractors/test_asserts.py
+++ b/tests/test_linter/test_extractors/test_asserts.py
@@ -15,6 +15,12 @@ from deal.linter._extractors import get_asserts
     ('assert 0', (0, )),
     ('assert False', (False, )),
     ('assert ""', ('', )),
+    ('assert []', ([], )),
+
+    ('assert 3 - 2', ()),
+    # ('assert 2 - 2', (0, )),
+    ('assert a', ()),           # ignore uninferrable names
+    ('a = object()\nassert a', ()),
 ])
 def test_get_asserts_simple(text, expected):
     tree = astroid.parse(text)
@@ -24,20 +30,5 @@ def test_get_asserts_simple(text, expected):
 
     tree = ast.parse(text)
     print(ast.dump(tree))
-    returns = tuple(r.value for r in get_asserts(body=tree.body))
-    assert returns == expected
-
-
-@pytest.mark.parametrize('text, expected', [
-    ('assert 3 - 2', ()),
-    ('assert a', ()),           # ignore uninferrable names
-    ('a = object()\nassert a', ()),
-
-    ('assert 2 - 2', (0, )),    # do a simple arithmetic
-    ('a = ""\nassert a', ('', )),
-])
-def test_get_asserts_inference(text, expected):
-    tree = astroid.parse(text)
-    print(tree.repr_tree())
     returns = tuple(r.value for r in get_asserts(body=tree.body))
     assert returns == expected

--- a/tests/test_linter/test_extractors/test_exceptions.py
+++ b/tests/test_linter/test_extractors/test_exceptions.py
@@ -14,6 +14,7 @@ from deal.linter._extractors import get_exceptions
     ('raise ValueError("lol")', (ValueError, )),
     ('raise unknown()', ()),
     ('raise 1 + 2', ()),
+    ('raise', ()),
     ('assert False', (AssertionError, )),
     ('12 / 0', (ZeroDivisionError, )),
     ('12 + 0', ()),

--- a/tests/test_linter/test_rules.py
+++ b/tests/test_linter/test_rules.py
@@ -253,7 +253,7 @@ def test_check_has_io():
     checker = CheckMarkers()
     text = """
     @deal.pre(lambda a: len(a) > 2)
-    @deal.has('io')
+    @deal.has('io', 13)
     @deal.post(lambda result: result is not None)
     def test(a):
         import sys

--- a/tests/test_linter/test_rules.py
+++ b/tests/test_linter/test_rules.py
@@ -116,6 +116,21 @@ def test_check_raises():
         assert actual == expected
 
 
+def test_check_raises__skip_asserts():
+    checker = CheckRaises()
+    text = """
+    @deal.pure
+    def test(a):
+        assert False
+        raise AssertionError
+    """
+    text = dedent(text).strip()
+    funcs1 = Func.from_ast(ast.parse(text))
+    funcs2 = Func.from_astroid(astroid.parse(text))
+    for func in (funcs1[0], funcs2[0]):
+        assert list(checker(func)) == []
+
+
 def test_check_raises_safe():
     checker = CheckRaises()
     text = """

--- a/tests/test_linter/test_transformer.py
+++ b/tests/test_linter/test_transformer.py
@@ -312,6 +312,18 @@ def test_transformer_raises(content: str, tmp_path: Path) -> None:
             print("hi")
             return 1
     """,
+    # drop invalid markers
+    """
+        @deal.has(13, None, 'random', [])
+        def f():
+            print("hi")
+            return 1
+        ---
+        @deal.has('random', 'stdout')
+        def f():
+            print("hi")
+            return 1
+    """,
     # replace deal.pure
     """
         @deal.pure

--- a/tests/test_mem_test.py
+++ b/tests/test_mem_test.py
@@ -2,7 +2,7 @@ from deal._mem_test import MemoryTracker
 
 
 def test_mem_dump_no_diff():
-    def f():
+    def f() -> int:
         return 123
 
     tracker = MemoryTracker()
@@ -26,7 +26,7 @@ def test_mem_dump_ignore_locals():
 def test_mem_dump_side_effect():
     a = []
 
-    def f():
+    def f() -> int:
         a.append({12})
         return 123
 

--- a/tests/test_runtime/test_dispatch.py
+++ b/tests/test_runtime/test_dispatch.py
@@ -58,7 +58,7 @@ def test_propagate_pre_contract_error():
     f.register(double3)
 
     @deal.pre(lambda: False)
-    def bad_func():
+    def bad_func() -> int:
         return 0
 
     @f.register
@@ -77,7 +77,7 @@ def test_propagate_pre_contract_error_from_default():
     f.register(double3)
 
     @deal.pre(lambda: False)
-    def bad_func():
+    def bad_func() -> int:
         return 0
 
     @f.register

--- a/tests/test_runtime/test_ensure.py
+++ b/tests/test_runtime/test_ensure.py
@@ -7,7 +7,7 @@ from .helpers import run_sync
 
 def test_parameters_and_result_fulfill_constact():
     @deal.ensure(lambda a, b, result: a > 0 and b > 0 and result != 'same number')
-    def func(a, b):
+    def func(a, b) -> str:
         if a == b:
             return 'same number'
         else:
@@ -24,7 +24,7 @@ def test_parameters_and_result_fulfill_constact():
 
 def test_simple_signature():
     @deal.ensure(lambda _: _.a > 0 and _.b > 0 and _.result != 'same number')
-    def func(a, b):
+    def func(a, b) -> str:
         if a == b:
             return 'same number'
         else:
@@ -41,7 +41,7 @@ def test_simple_signature():
 
 def test_decorating_async_function():
     @deal.ensure(lambda a, b, result: a > 0 and b > 0 and result != 'same number')
-    async def func(a, b):
+    async def func(a, b) -> str:
         if a == b:
             return 'same number'
         else:

--- a/tests/test_runtime/test_example.py
+++ b/tests/test_runtime/test_example.py
@@ -9,7 +9,7 @@ from .helpers import run_sync
 def test_example_is_not_triggered_in_runtime():
     @deal.example(lambda: False)
     @deal.example(lambda: 1 / 0 == 0)
-    def f1():
+    def f1() -> bool:
         return True
 
     assert f1() is True
@@ -29,7 +29,7 @@ def test_example_does_not_break_iterator():
 def test_example_does_not_break_async():
     @deal.example(lambda: False)
     @deal.example(lambda: 1 / 0 == 0)
-    async def f1():
+    async def f1() -> bool:
         return True
 
     assert iscoroutinefunction(f1) is True

--- a/tests/test_runtime/test_offline.py
+++ b/tests/test_runtime/test_offline.py
@@ -46,7 +46,7 @@ def test_allow_network():
 
 def test_decorating_async_function():
     @deal.has()
-    async def func(do):
+    async def func(do) -> int:
         if not do:
             return 1
         http = urllib3.PoolManager()

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -12,7 +12,7 @@ class MarshMallowScheme(marshmallow.Schema):
 
 
 class CustomScheme(deal.Scheme):
-    def is_valid(self):
+    def is_valid(self) -> bool:
         if not isinstance(self.data['name'], str):
             self.errors = vaa.Error.parse({'name': ['Not a valid string.']})
             return False

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -81,7 +81,7 @@ def test_no_bad_examples():
 
 
 def test_return_type_checks():
-    def div(a: int, b: int):
+    def div(a: int, b: int) -> int:
         return 1
 
     for case in deal.cases(div, count=20):

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -4,11 +4,11 @@ import deal
 from deal._trace import Only, _get_func_body_statements, format_lines, trace
 
 
-def just_return():
+def just_return() -> int:
     return 123
 
 
-def cond_return(cond=False):
+def cond_return(cond=False) -> int:
     if cond:
         return 123
     return 456
@@ -16,7 +16,7 @@ def cond_return(cond=False):
 
 @deal.safe
 @deal.has()
-def cond_return_dec(cond=False):
+def cond_return_dec(cond=False) -> int:
     if cond:
         return 123
     return 456
@@ -27,7 +27,7 @@ def call_another():
     return cond_return(cond=cond)
 
 
-def something_else():
+def something_else() -> bool:
     return False
 
 


### PR DESCRIPTION
1. Do not infer test condition for `assert`, report only explicit falsy conditions.
2. Do not report `AssertionError` in `raises`, assume it to be implicitly declared. The motivation is that `AssertionError` is supposed to be used in the same way as contracts: to assert conditions that never fail on the prod.
3. Add some missed type annotations