### PR TITLE
Make some dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Read more in the [documentation](https://deal.readthedocs.io/).
 ## Installation
 
 ```bash
-python3 -m pip install --user deal
+python3 -m pip install --user 'deal[all]'
 ```
 
 ## Contributing

--- a/deal/_cli/_prove.py
+++ b/deal/_cli/_prove.py
@@ -13,7 +13,7 @@ from ._common import get_paths
 
 try:
     import deal_solver
-except ImportError:
+except ImportError:  # pragma: no cover
     deal_solver = None  # type: ignore
 
 if TYPE_CHECKING:

--- a/deal/_cli/_prove.py
+++ b/deal/_cli/_prove.py
@@ -1,6 +1,6 @@
+import sys
 from argparse import ArgumentParser
 from pathlib import Path
-import sys
 from typing import TYPE_CHECKING, Dict, Iterator, TextIO
 
 from .._colors import get_colors
@@ -16,7 +16,6 @@ except ImportError:
 
 if TYPE_CHECKING:
     import astroid
-    from deal_solver import Contract
 
 
 TEMPLATE_MOD = '{blue}{name}{end}'
@@ -26,7 +25,7 @@ TEMPLATE_CON = '    {color}{p.conclusion.value}{end} {p}'
 
 class DealTheorem(deal_solver.Theorem):
     @staticmethod
-    def get_contracts(func: 'astroid.FunctionDef') -> Iterator['Contract']:
+    def get_contracts(func: 'astroid.FunctionDef') -> Iterator['deal_solver.Contract']:
         for contract in get_contracts(func):
             yield deal_solver.Contract(
                 name=contract.name,

--- a/deal/_cli/_prove.py
+++ b/deal/_cli/_prove.py
@@ -3,8 +3,6 @@ from pathlib import Path
 import sys
 from typing import TYPE_CHECKING, Dict, Iterator, TextIO
 
-import astroid
-
 from .._colors import get_colors
 from ..linter._extractors import get_contracts
 from ._base import Command
@@ -17,6 +15,7 @@ except ImportError:
     deal_solver = None  # type: ignore
 
 if TYPE_CHECKING:
+    import astroid
     from deal_solver import Contract
 
 
@@ -27,7 +26,7 @@ TEMPLATE_CON = '    {color}{p.conclusion.value}{end} {p}'
 
 class DealTheorem(deal_solver.Theorem):
     @staticmethod
-    def get_contracts(func: astroid.FunctionDef) -> Iterator['Contract']:
+    def get_contracts(func: 'astroid.FunctionDef') -> Iterator['Contract']:
         for contract in get_contracts(func):
             yield deal_solver.Contract(
                 name=contract.name,

--- a/deal/_cli/_prove.py
+++ b/deal/_cli/_prove.py
@@ -12,7 +12,7 @@ from ._common import get_paths
 try:
     import deal_solver
 except ImportError:
-    deal_solver = None  # type: ignore
+    deal_solver = None
 
 if TYPE_CHECKING:
     import astroid
@@ -29,7 +29,7 @@ class DealTheorem(deal_solver.Theorem):
         for contract in get_contracts(func):
             yield deal_solver.Contract(
                 name=contract.name,
-                args=contract.args,  # type: ignore[arg-type]
+                args=contract.args,
             )
 
 

--- a/deal/_cli/_prove.py
+++ b/deal/_cli/_prove.py
@@ -13,7 +13,7 @@ from ._common import get_paths
 
 try:
     import deal_solver
-except ImportError:  # pragma: no cover
+except ImportError:
     deal_solver = None  # type: ignore
 
 if TYPE_CHECKING:

--- a/deal/_cli/_test.py
+++ b/deal/_cli/_test.py
@@ -9,10 +9,6 @@ from pathlib import Path
 from textwrap import indent
 from typing import Dict, Iterable, Iterator, TextIO, TypeVar
 
-import pygments
-from pygments.formatters import TerminalFormatter
-from pygments.lexers import PythonTracebackLexer
-
 from .._colors import COLORS
 from .._testing import TestCase, cases
 from .._trace import TraceResult, format_lines, trace
@@ -21,6 +17,14 @@ from ..linter._extractors.pre import format_call_args
 from ..linter._func import Func
 from ._base import Command
 from ._common import get_paths
+
+try:
+    import pygments
+except ImportError:  # pragma: no cover
+    pygments = None
+else:
+    from pygments.formatters import TerminalFormatter
+    from pygments.lexers import PythonTracebackLexer
 
 
 T = TypeVar('T')
@@ -56,6 +60,8 @@ def get_func_names(path: Path) -> Iterator[str]:
 
 def color_exception(text: str) -> str:
     text = rex_exception.sub(r'\1', text)
+    if pygments is None:  # pragma: no cover
+        return text
     return pygments.highlight(
         code=text,
         lexer=PythonTracebackLexer(),

--- a/deal/_cli/_test.py
+++ b/deal/_cli/_test.py
@@ -20,7 +20,7 @@ from ._common import get_paths
 
 try:
     import pygments
-except ImportError:  # pragma: no cover
+except ImportError:
     pygments = None
 else:
     from pygments.formatters import TerminalFormatter

--- a/deal/_cli/_test.py
+++ b/deal/_cli/_test.py
@@ -18,6 +18,7 @@ from ..linter._func import Func
 from ._base import Command
 from ._common import get_paths
 
+
 try:
     import pygments
 except ImportError:

--- a/deal/_colors.py
+++ b/deal/_colors.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from ._state import state
 
+
 try:
     import pygments
 except ImportError:

--- a/deal/_colors.py
+++ b/deal/_colors.py
@@ -5,7 +5,7 @@ from ._state import state
 
 try:
     import pygments
-except ImportError:  # pragma: no cover
+except ImportError:
     pygments = None
 else:
     from pygments.formatters import TerminalFormatter

--- a/deal/_colors.py
+++ b/deal/_colors.py
@@ -1,11 +1,15 @@
 
 from typing import Dict
 
-import pygments
-from pygments.formatters import TerminalFormatter
-from pygments.lexers import PythonLexer
-
 from ._state import state
+
+try:
+    import pygments
+except ImportError:  # pragma: no cover
+    pygments = None
+else:
+    from pygments.formatters import TerminalFormatter
+    from pygments.lexers import PythonLexer
 
 
 COLORS = dict(
@@ -27,6 +31,8 @@ NOCOLORS = dict(
 
 
 def highlight(source: str) -> str:
+    if pygments is None:  # pragma: no cover
+        return source
     source = pygments.highlight(
         code=source,
         lexer=PythonLexer(),

--- a/deal/_testing.py
+++ b/deal/_testing.py
@@ -9,11 +9,11 @@ from ._cached_property import cached_property
 try:
     import typeguard
 except ImportError:
-    typeguard = None  # type: ignore
+    typeguard = None
 try:
     import hypothesis
 except ImportError:
-    hypothesis = None  # type: ignore
+    hypothesis = None
 else:
     import hypothesis.strategies
     from hypothesis.internal.reflection import proxies

--- a/deal/_testing.py
+++ b/deal/_testing.py
@@ -93,7 +93,7 @@ class cases:  # noqa: N
         func: typing.Callable, *,
         count: int = 50,
         kwargs: typing.Optional[typing.Dict[str, typing.Any]] = None,
-        check_types: bool = True,
+        check_types: typing.Optional[bool] = None,
         settings: typing.Optional[hypothesis.settings] = None,
         seed: typing.Optional[int] = None,
     ) -> None:
@@ -111,6 +111,11 @@ class cases:  # noqa: N
         ```
 
         """
+        if check_types is True and typeguard is None:  # pragma: no cover
+            raise ImportError('typeguard is not installed')
+        if check_types is None:
+            check_types = True
+
         self.func = func  # type: ignore
         self.count = count
         self.kwargs = kwargs or {}

--- a/deal/_testing.py
+++ b/deal/_testing.py
@@ -5,6 +5,7 @@ from inspect import signature
 from . import introspection
 from ._cached_property import cached_property
 
+
 try:
     import typeguard
 except ImportError:

--- a/deal/_testing.py
+++ b/deal/_testing.py
@@ -4,12 +4,15 @@ from inspect import signature
 
 import hypothesis
 import hypothesis.strategies
-import typeguard
 from hypothesis.internal.reflection import proxies
 
 from . import introspection
 from ._cached_property import cached_property
 
+try:
+    import typeguard
+except ImportError:
+    typeguard = None  # type: ignore
 
 F = typing.Callable[..., None]
 FuzzInputType = typing.Union[bytes, bytearray, memoryview, typing.BinaryIO]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,13 @@ classifiers=[
 
 requires = [
     "astroid",
-    "hypothesis",
     "vaa>=0.2.1",
 ]
 
 [tool.flit.metadata.requires-extra]
 all = [
     "deal-solver",
+    "hypothesis",
     "pygments",
     "typeguard",
 ]
@@ -46,6 +46,7 @@ test = [
 
     # copy-pasted "all" extra
     "deal-solver",
+    "hypothesis",
     "pygments",
     "typeguard",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers=[
 
 requires = [
     "astroid",
-    "deal-solver",
     "hypothesis",
     "pygments",
     "typeguard",
@@ -33,8 +32,12 @@ requires = [
 ]
 
 [tool.flit.metadata.requires-extra]
+all = [
+    "deal-solver",
+]
 test = [
     "coverage[toml]",
+    "deal-solver",
     "pytest-cov",
     "isort",
     "marshmallow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,15 +37,17 @@ all = [
 ]
 test = [
     "coverage[toml]",
-    "deal-solver",
     "isort",
     "marshmallow",
-    "pygments",
     "pytest-cov",
     "pytest",
     "sphinx",
-    "typeguard",
     "urllib3",
+
+    # copy-pasted "all" extra
+    "deal-solver",
+    "pygments",
+    "typeguard",
 ]
 lint = [
     "flake8",
@@ -84,6 +86,7 @@ omit = [
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
+    "except ImportError:",
     "raise NotImplementedError",
     "  pass",
     "if TYPE_CHECKING:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,13 @@ classifiers=[
 requires = [
     "astroid",
     "hypothesis",
-    "pygments",
     "vaa>=0.2.1",
 ]
 
 [tool.flit.metadata.requires-extra]
 all = [
     "deal-solver",
+    "pygments",
     "typeguard",
 ]
 test = [
@@ -40,6 +40,7 @@ test = [
     "deal-solver",
     "isort",
     "marshmallow",
+    "pygments",
     "pytest-cov",
     "pytest",
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,23 +27,24 @@ requires = [
     "astroid",
     "hypothesis",
     "pygments",
-    "typeguard",
     "vaa>=0.2.1",
 ]
 
 [tool.flit.metadata.requires-extra]
 all = [
     "deal-solver",
+    "typeguard",
 ]
 test = [
     "coverage[toml]",
     "deal-solver",
-    "pytest-cov",
     "isort",
     "marshmallow",
+    "pytest-cov",
     "pytest",
-    "urllib3",
     "sphinx",
+    "typeguard",
+    "urllib3",
 ]
 lint = [
     "flake8",


### PR DESCRIPTION
Do not require dependencies that are used only in a few places:

+ typeguard
+ hypothesis
+ pygments
+ deal_solver

If you have a new `ImportError` after the upgrade when using `deal.cases` or `deal prove`, you need to install the project as `deal[all]` in your requirements file. Sorry for the inconvenience.