### PR TITLE
Don't call typeguard if it's not available

### DIFF
--- a/deal/_testing.py
+++ b/deal/_testing.py
@@ -63,7 +63,7 @@ class TestCase(typing.NamedTuple):
         return result
 
     def _check_result(self, result: typing.Any) -> None:
-        if not self.check_types:
+        if not self.check_types or typeguard is None:
             return
         memo = typeguard._CallMemo(
             func=self.func,


### PR DESCRIPTION
Attempting to run the "deal in 30s" example:

```python
# the result is always non-negative
@deal.post(lambda result: result >= 0)
# the function has no side-effects
@deal.pure
def count(items: List[str], item: str) -> int:
    return items.count(item)

# generate test function
test_count = deal.cases(count)
```

fails with the following error run under pytest:

```
[nix-shell:~/code/nixpkgs]$ pytest deal_test.py
======================================================== test session starts ========================================================
platform darwin -- Python 3.9.11, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/panashe/code/nixpkgs
plugins: hypothesis-6.38.0
collected 1 item

deal_test.py F                                                                                                                [100%]

============================================================= FAILURES ==============================================================
____________________________________________________________ test_count _____________________________________________________________

>   ???

/nix/store/3mnlyndr9s9r0v49ynahldczkawqa076-python3.9-deal-4.21.1/lib/python3.9/site-packages/deal/_testing.py:329:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/3mnlyndr9s9r0v49ynahldczkawqa076-python3.9-deal-4.21.1/lib/python3.9/site-packages/deal/_testing.py:328: in <lambda>
    return self._wrap(lambda case: case())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = TestCase(args=(), kwargs={'items': [], 'item': ''}, func=<function count at 0x10fe74af0>, exceptions=(), check_types=True)
result = 0

    def _check_result(self, result: typing.Any) -> None:
        if not self.check_types:
            return
>       memo = typeguard._CallMemo(
            func=self.func,
            args=self.args,
            kwargs=self.kwargs,
        )
E       AttributeError: 'NoneType' object has no attribute '_CallMemo'

/nix/store/3mnlyndr9s9r0v49ynahldczkawqa076-python3.9-deal-4.21.1/lib/python3.9/site-packages/deal/_testing.py:68: AttributeError
------------------------------------------------------- Captured stdout call --------------------------------------------------------

You can reproduce this example by temporarily adding @reproduce_failure('6.38.0', b'AAAA') as a decorator on your test case
====================================================== short test summary info ======================================================
FAILED deal_test.py::test_count - AttributeError: 'NoneType' object has no attribute '_CallMemo'
========================================================= 1 failed in 0.81s =========================================================
```

This does not fail if you just call `deal.cases(count)()`. Looking into the failure, this is attempting to call `typeguard` when the dependency is not available. In the constructor, `self.check_types` defaults to `True` when not passed, but there is no explicit check that typeguard exists before using it, even though it should optional.