### PR TITLE
Support deal.pure in code generator

### DIFF
--- a/deal/_cli/_decorate.py
+++ b/deal/_cli/_decorate.py
@@ -29,7 +29,7 @@ class DecorateCommand(Command):
             '--types',
             nargs='*',
             choices=[tt.value for tt in TransformationType],
-            default=['has', 'raises', 'safe', 'import'],
+            default=['has', 'raises', 'safe', 'import', 'pure'],
             help='types of decorators to apply',
         )
         parser.add_argument(

--- a/deal/_cli/_decorate.py
+++ b/deal/_cli/_decorate.py
@@ -29,7 +29,7 @@ class DecorateCommand(Command):
             '--types',
             nargs='*',
             choices=[tt.value for tt in TransformationType],
-            default=['has', 'raises', 'safe', 'import', 'pure'],
+            default=sorted(tt.value for tt in TransformationType),
             help='types of decorators to apply',
         )
         parser.add_argument(

--- a/deal/linter/_extractors/common.py
+++ b/deal/linter/_extractors/common.py
@@ -30,6 +30,7 @@ class TOKENS:
     RAISE: N[ast.Raise] = (ast.Raise, astroid.Raise)
     RETURN: N[ast.Return] = (ast.Return, astroid.Return)
     YIELD: N[ast.Yield] = (ast.Yield, astroid.Yield)
+    YIELD_FROM: N[ast.YieldFrom] = (ast.YieldFrom, astroid.YieldFrom)
 
 
 DEFAULT_LINE = 0

--- a/deal/linter/_extractors/exceptions.py
+++ b/deal/linter/_extractors/exceptions.py
@@ -124,17 +124,15 @@ def _exceptions_from_func(expr: Union[ast.Call, astroid.Call]) -> Iterator[Token
 
         # get exceptions from the docstring
         name: str
-        for name in _excs_from_doc(value.doc):
-            name = getattr(builtins, name, name)
-            yield Token(value=name)
+        if value.doc_node is not None:
+            for name in _excs_from_doc(value.doc_node.value):
+                name = getattr(builtins, name, name)
+                yield Token(value=name)
     return None
 
 
 # TODO: use it on the target function docstring too
-def _excs_from_doc(doc: Optional[str]) -> Iterator[str]:
-    if doc is None:
-        return
-
+def _excs_from_doc(doc: str) -> Iterator[str]:
     if docstring_parser is not None:
         parsed = docstring_parser.parse(doc)
         for exc_info in parsed.raises:

--- a/deal/linter/_extractors/exceptions.py
+++ b/deal/linter/_extractors/exceptions.py
@@ -11,6 +11,7 @@ from .._stub import StubsManager
 from .common import TOKENS, Extractor, Token, get_full_name, get_name, get_stub, infer
 from .contracts import get_contracts
 
+
 try:
     import docstring_parser
 except ImportError:

--- a/deal/linter/_extractors/returns.py
+++ b/deal/linter/_extractors/returns.py
@@ -1,6 +1,7 @@
 import ast
-import astroid
 from typing import Optional, Union
+
+import astroid
 
 from .common import TOKENS, Extractor, Token, traverse
 from .value import UNKNOWN, get_value

--- a/deal/linter/_extractors/returns.py
+++ b/deal/linter/_extractors/returns.py
@@ -8,8 +8,9 @@ get_returns = Extractor()
 
 
 def has_returns(body: list) -> bool:
+    expected = TOKENS.RETURN + TOKENS.YIELD + TOKENS.YIELD_FROM + TOKENS.RAISE
     for expr in traverse(body=body):
-        if isinstance(expr, TOKENS.RETURN + TOKENS.YIELD):
+        if isinstance(expr, expected):
             return True
     return False
 

--- a/deal/linter/_extractors/returns.py
+++ b/deal/linter/_extractors/returns.py
@@ -1,4 +1,6 @@
-from typing import Optional
+import ast
+import astroid
+from typing import Optional, Union
 
 from .common import TOKENS, Extractor, Token, traverse
 from .value import UNKNOWN, get_value
@@ -16,7 +18,9 @@ def has_returns(body: list) -> bool:
 
 
 @get_returns.register(*TOKENS.RETURN)
-def handle_return(expr) -> Optional[Token]:
+def handle_return(expr: Union[ast.Return, astroid.Return]) -> Optional[Token]:
+    if expr.value is None:
+        return Token(value=None, line=expr.lineno, col=expr.col_offset)
     value = get_value(expr=expr.value)
     if value is UNKNOWN:
         return None
@@ -24,7 +28,9 @@ def handle_return(expr) -> Optional[Token]:
 
 
 @get_returns.register(*TOKENS.YIELD)
-def handle_yield(expr) -> Optional[Token]:
+def handle_yield(expr: Union[ast.Yield, astroid.Yield]) -> Optional[Token]:
+    if expr.value is None:
+        return Token(value=None, line=expr.lineno, col=expr.col_offset)
     value = get_value(expr=expr.value)
     if value is UNKNOWN:
         return None

--- a/deal/linter/_func.py
+++ b/deal/linter/_func.py
@@ -22,6 +22,18 @@ class Func(NamedTuple):
     def col(self) -> int:
         return self.node.col_offset
 
+    @property
+    def has_self(self) -> bool:
+        """Check if the first function argument is `self`.
+        """
+        args = self.node.args.args
+        if not args:
+            return False
+        arg = args[0]
+        if isinstance(arg, ast.arg):
+            return arg.arg == 'self'
+        return arg.name == 'self'
+
     @classmethod
     def from_path(cls, path: Path) -> List['Func']:
         text = path.read_text()
@@ -110,6 +122,8 @@ class Func(NamedTuple):
                     yield stmt
 
     def has_contract(self, *categories: Category) -> bool:
+        """Check if the function has a contract from any of the given categories.
+        """
         for contract in self.contracts:
             if contract.category in categories:
                 return True

--- a/deal/linter/_rules.py
+++ b/deal/linter/_rules.py
@@ -313,7 +313,7 @@ class CheckMarkers(FuncRule):
     def get_undeclared(cls, func: Func, markers: Set[str]) -> Iterator[Error]:
         has = HasPatcher(markers)
         # function without IO must return something
-        if not has.has_io and not has_returns(body=func.body):
+        if not has.has_io and not func.has_self and not has_returns(body=func.body):
             yield Error(
                 code=cls.codes['io'],
                 text=cls.message,
@@ -330,7 +330,7 @@ class CheckMarkers(FuncRule):
             if has_marker:
                 continue
             yield Error(
-                code=cls.codes.get(token.marker, 40),
+                code=cls.codes.get(token.marker, cls.code),
                 text=cls.message,
                 value=token.marker,
                 row=token.line,

--- a/deal/linter/_transformer.py
+++ b/deal/linter/_transformer.py
@@ -205,7 +205,7 @@ class Transformer(NamedTuple):
             )
             return
 
-        # if new markers detected, remove old contracts and add a new deal.raises
+        # if new markers detected, remove old contracts and add a new deal.has
         for contract in func.contracts:
             if contract.category not in cats:
                 continue

--- a/deal/linter/_transformer.py
+++ b/deal/linter/_transformer.py
@@ -296,7 +296,7 @@ class Transformer(NamedTuple):
                 continue
             if mut.line not in lines:
                 continue
-            assert mut.contract in old_cats, "unexpected contract added"
+            assert mut.contract in old_cats, 'unexpected contract generated'
             self.mutations.remove(mut)
             if mut.contract == Category.SAFE:
                 yield mut._replace(contract=Category.PURE)

--- a/deal/linter/_transformer.py
+++ b/deal/linter/_transformer.py
@@ -296,8 +296,7 @@ class Transformer(NamedTuple):
                 continue
             if mut.line not in lines:
                 continue
-            if mut.contract not in old_cats:
-                continue
+            assert mut.contract in old_cats, "unexpected contract added"
             self.mutations.remove(mut)
             if mut.contract == Category.SAFE:
                 yield mut._replace(contract=Category.PURE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers=[
 ]
 
 requires = [
-    "astroid",
+    "astroid>=2.11.0",
     "vaa>=0.2.1",
 ]
 

--- a/tests/test_linter/test_extractors/test_exceptions.py
+++ b/tests/test_linter/test_extractors/test_exceptions.py
@@ -1,6 +1,6 @@
 import ast
-from pathlib import Path
 import sys
+from pathlib import Path
 from textwrap import dedent
 from typing import Dict
 

--- a/tests/test_linter/test_extractors/test_returns.py
+++ b/tests/test_linter/test_extractors/test_returns.py
@@ -18,6 +18,7 @@ from deal.linter._extractors import get_returns, has_returns
     ('return True', (True, )),
     ('return None', (None, )),
     ('return [1,2,3]', ([1, 2, 3], )),
+    ('return', (None, )),
 
     ('if True: return 13', (13, )),
     ('if True:\n  return 13\nelse:\n  return 16', (13, 16)),
@@ -30,6 +31,7 @@ from deal.linter._extractors import get_returns, has_returns
     ('yield -1', (-1, )),
     ('yield True', (True, )),
     ('yield a', ()),
+    ('yield', (None, )),
 ])
 def test_get_returns_simple(text, expected):
     tree = astroid.parse(text)

--- a/tests/test_linter/test_transformer.py
+++ b/tests/test_linter/test_transformer.py
@@ -417,11 +417,37 @@ def test_transformer_has(content: str, tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize('content', [
-    # add deal.pure
+    # add @deal.pure
     """
         def f():
             return 1
         ---
+        @deal.pure
+        def f():
+            return 1
+    """,
+    # if not merged into @deal.pure, remove @deal.safe
+    """
+        def f():
+            print("hi")
+        ---
+        def f():
+            print("hi")
+    """,
+    # if not merged into @deal.pure, remove @deal.has()
+    """
+        def f():
+            return 1/0
+        ---
+        def f():
+            return 1/0
+    """,
+    """
+        @property
+        def f():
+            return 1
+        ---
+        @property  # type: ignore[misc]
         @deal.pure
         def f():
             return 1
@@ -434,7 +460,7 @@ def test_transformer_pure(content: str, tmp_path: Path) -> None:
     tr = Transformer(
         content=given,
         path=tmp_path / 'example.py',
-        types={TransformationType.PURE, TransformationType.HAS, TransformationType.SAFE},
+        types={TransformationType.PURE},
     )
     actual = tr.transform()
     assert actual == expected

--- a/tests/test_linter/test_transformer.py
+++ b/tests/test_linter/test_transformer.py
@@ -417,6 +417,30 @@ def test_transformer_has(content: str, tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize('content', [
+    # add deal.pure
+    """
+        def f():
+            return 1
+        ---
+        @deal.pure
+        def f():
+            return 1
+    """,
+])
+def test_transformer_pure(content: str, tmp_path: Path) -> None:
+    given, expected = content.split('---')
+    given = dedent(given)
+    expected = dedent(expected)
+    tr = Transformer(
+        content=given,
+        path=tmp_path / 'example.py',
+        types={TransformationType.PURE, TransformationType.HAS, TransformationType.SAFE},
+    )
+    actual = tr.transform()
+    assert actual == expected
+
+
+@pytest.mark.parametrize('content', [
     # add import if needed
     """
         def f():


### PR DESCRIPTION
If a function has both `deal.has()` and `deal.safe` detected, emit instead a single `deal.pure`