### PR TITLE
Fix incompatible type in raises(SystemExit)

### DIFF
--- a/deal/_runtime/_decorators.py
+++ b/deal/_runtime/_decorators.py
@@ -158,7 +158,7 @@ def ensure(
 
 
 def raises(
-    *exceptions: type[Exception],
+    *exceptions: type[BaseException],
     message: str | None = None,
     exception: ExceptionType | None = None,
 ) -> Callable[[C], C]:


### PR DESCRIPTION
The deal linter decorates functions that call sys.exit() with
`@deal.raises(SystemExit)`. SystemExit inherits from BaseException,
which makes it incompatible with Exception:

```
dumbpw/cli.py:14:14: error: Argument 1 to "raises" has incompatible type
"Type[SystemExit]"; expected "Type[Exception]"  [arg-type]
    @deal.raises(SystemExit)
                 ^
Found 1 error in 1 file (checked 14 source files)
```

This change annotates the raises() decorator to expect BaseException so
that SystemExit can be included without an incompatible type error from
the type checker.