### PR TITLE
linter: detect `self` even when it is a posonlyarg

### DIFF
--- a/deal/linter/_extractors/pre.py
+++ b/deal/linter/_extractors/pre.py
@@ -35,7 +35,8 @@ def handle_call(expr: astroid.Call, context: dict[str, ast.stmt] | None = None) 
         if not isinstance(func, astroid.FunctionDef):
             continue
         code = f'def f({func.args.as_string()}):0'
-        func_args = ast.parse(code).body[0].args  # type: ignore
+        func_ast = ast.parse(code).body[0]
+        assert isinstance(func_ast, ast.FunctionDef)
         for cinfo in get_contracts(func):
             if cinfo.name != 'pre':
                 continue
@@ -43,7 +44,7 @@ def handle_call(expr: astroid.Call, context: dict[str, ast.stmt] | None = None) 
                 args=cinfo.args,
                 kwargs=cinfo.kwargs,
                 category=Category.PRE,
-                func_args=func_args,
+                func_args=func_ast.args,
                 context=context,
             )
             try:

--- a/deal/linter/_func.py
+++ b/deal/linter/_func.py
@@ -28,9 +28,7 @@ class Func(NamedTuple):
     def has_self(self) -> bool:
         """Check if the first function argument is `self`.
         """
-        args = getattr(self.node.args, 'posonlyargs', None)
-        if not args:
-            args = self.node.args.args
+        args = getattr(self.node.args, 'posonlyargs', None) or self.node.args.args
         if not args:
             return False
         arg = args[0]

--- a/deal/linter/_func.py
+++ b/deal/linter/_func.py
@@ -28,7 +28,9 @@ class Func(NamedTuple):
     def has_self(self) -> bool:
         """Check if the first function argument is `self`.
         """
-        args = self.node.args.args
+        args = getattr(self.node.args, 'posonlyargs', None)
+        if not args:
+            args = self.node.args.args
         if not args:
             return False
         arg = args[0]

--- a/tests/test_linter/helpers.py
+++ b/tests/test_linter/helpers.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import ast
-import astroid
 from textwrap import dedent
 from typing import TypeVar
+
+import astroid
+
 from deal.linter._func import Func
+
 
 T = TypeVar('T')
 

--- a/tests/test_linter/helpers.py
+++ b/tests/test_linter/helpers.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import ast
+import astroid
+from textwrap import dedent
+from typing import TypeVar
+from deal.linter._func import Func
+
+T = TypeVar('T')
+
+
+def first(funcs: list[T]) -> T:
+    assert len(funcs) == 1
+    return funcs[0]
+
+
+def funcs_from_ast(text: str) -> list[Func]:
+    text = dedent(text).strip()
+    tree = ast.parse(text)
+    print(ast.dump(tree))
+    return Func.from_ast(tree)
+
+
+def funcs_from_astroid(text: str) -> list[Func]:
+    text = dedent(text).strip()
+    tree = astroid.parse(text)
+    print(tree.repr_tree())
+    return Func.from_astroid(tree)

--- a/tests/test_linter/test_contract.py
+++ b/tests/test_linter/test_contract.py
@@ -6,6 +6,7 @@ import pytest
 
 from deal.linter._contract import Category, Contract, NoValidatorError
 from deal.linter._func import Func
+
 from .helpers import first, funcs_from_ast, funcs_from_astroid
 
 

--- a/tests/test_linter/test_contract.py
+++ b/tests/test_linter/test_contract.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import ast
-from textwrap import dedent
-from typing import Iterator, TypeVar
+from typing import Iterator
 
-import astroid
 import pytest
 
 from deal.linter._contract import Category, Contract, NoValidatorError
 from deal.linter._func import Func
+from .helpers import first, funcs_from_ast, funcs_from_astroid
 
 
 TEXT = """
@@ -19,26 +17,6 @@ TEXT = """
     def f(x):
         return x
 """
-T = TypeVar('T')
-
-
-def first(funcs: list[T]) -> T:
-    assert len(funcs) == 1
-    return funcs[0]
-
-
-def funcs_from_ast(text: str) -> list[Func]:
-    text = dedent(text).strip()
-    tree = ast.parse(text)
-    print(ast.dump(tree))
-    return Func.from_ast(tree)
-
-
-def funcs_from_astroid(text: str) -> list[Func]:
-    text = dedent(text).strip()
-    tree = astroid.parse(text)
-    print(tree.repr_tree())
-    return Func.from_astroid(tree)
 
 
 def iter_funcs(text: str) -> Iterator[Func]:
@@ -196,10 +174,7 @@ def test_resolve_and_run_dependencies_func_astroid():
     def f(a):
         return a * 2
     """
-    text = dedent(text).strip()
-    tree = astroid.parse(text)
-    print(tree.repr_tree())
-    funcs = Func.from_astroid(tree)
+    funcs = funcs_from_astroid(text)
     assert len(funcs) == 2
     c = first(funcs[-1].contracts)
     assert c.run(12) is False

--- a/tests/test_linter/test_func.py
+++ b/tests/test_linter/test_func.py
@@ -6,6 +6,7 @@ import astroid
 import pytest
 
 from deal.linter._func import Func
+
 from .helpers import first, funcs_from_astroid
 
 

--- a/tests/test_linter/test_func.py
+++ b/tests/test_linter/test_func.py
@@ -1,9 +1,12 @@
 import ast
+import sys
 from textwrap import dedent
 
 import astroid
+import pytest
 
 from deal.linter._func import Func
+from .helpers import first, funcs_from_astroid
 
 
 TEXT = """
@@ -77,3 +80,31 @@ def test_repr():
     funcs2 = Func.from_astroid(astroid.parse(dedent(TEXT)))
     for func in (funcs1[0], funcs2[0]):
         assert repr(func) == 'Func(post, raises)'
+
+
+mark38 = pytest.mark.skipif(sys.version_info < (3, 8), reason='old python')
+
+
+@pytest.mark.parametrize('signature, expected', [
+    ('self', True),
+    ('self, a', True),
+    ('self, *a, **k', True),
+    ('self, *, a', True),
+
+    ('a', False),
+    ('a, b', False),
+    ('*self', False),
+    ('**self', False),
+
+    pytest.param('self, /, a', True, marks=mark38),
+    pytest.param('self, a, /, b', True, marks=mark38),
+    pytest.param('a, /, b', False, marks=mark38),
+])
+def test_has_self(signature, expected):
+    text = f"""
+        @deal.post(lambda x: x > 0)
+        def f({signature}):
+            return x
+    """
+    func = first(funcs_from_astroid(text))
+    assert func.has_self is expected


### PR DESCRIPTION
Linter used to not detect self when it is a positional-only argument.