### PR TITLE
Make vaa optional

### DIFF
--- a/deal/_runtime/_validators.py
+++ b/deal/_runtime/_validators.py
@@ -110,11 +110,6 @@ class Validator:
                 message = exception.args[0]
             exception = type(exception)
 
-        # if errors provided, use it as error message
-        if errors and isinstance(errors, str):
-            message = errors
-            errors = None
-
         # raise beautiful ContractError
         if issubclass(exception, ContractError):
             return exception(
@@ -134,7 +129,7 @@ class Validator:
         return exception(*args)
 
     def _wrap_vaa(self) -> Any | None:
-        if vaa is None:
+        if vaa is None:  # pragma: no cover
             return None
         try:
             return vaa.wrap(self.raw_validator, simple=False)
@@ -200,14 +195,6 @@ class Validator:
         errors = validator.errors
         if not errors:
             raise self._exception(params=params) from exc
-
-        # Flatten single error without field to one simple str message.
-        # This is for better readability of simple validators.
-        if type(errors) is list:  # pragma: no cover
-            if type(errors[0]) is vaa.Error:
-                if len(errors) == 1:
-                    if errors[0].field is None:
-                        errors = errors[0].message
 
         raise self._exception(errors=errors, params=params) from exc
 
@@ -289,3 +276,6 @@ class ReasonValidator(Validator):
 class InvariantValidator(Validator):
     def _vaa_validation(self, args: Args, kwargs: Kwargs, exc=None) -> None:
         return super()._vaa_validation((), vars(args[0]), exc=exc)
+
+    def _short_validation(self, args: Args, kwargs: Kwargs, exc=None) -> None:
+        return super()._short_validation((), vars(args[0]), exc=exc)

--- a/deal/_runtime/_validators.py
+++ b/deal/_runtime/_validators.py
@@ -52,11 +52,11 @@ def _args_to_vars(
     return params
 
 
-class BorgDict(dict):
+class AttrDict(dict):
+    __slots__ = ()
+
     def __getattr__(self, name: str):
-        if name in self:
-            return self[name]
-        raise AttributeError(name)
+        return self[name]
 
 
 class Validator:
@@ -239,7 +239,7 @@ class Validator:
             signature=self.signature,
             keep_result=False,
         )
-        validation_result = self.validator(BorgDict(params))
+        validation_result = self.validator(AttrDict(params))
         # is invalid (validator returns error message)
         if type(validation_result) is str:
             raise self._exception(message=validation_result, params=params) from exc

--- a/deal/_runtime/_validators.py
+++ b/deal/_runtime/_validators.py
@@ -148,25 +148,27 @@ class Validator:
         # implicitly wrap in vaa.simple only funcs with one `_` argument.
         self.signature = None
         val_signature = _get_signature(self.raw_validator)
+
+        # validator with a short signature
         if set(val_signature.parameters) == {'_'}:
-            # validator with a short signature
             self.validator = self.raw_validator
             self.validate = self._short_validation
             if self.function is not None:
                 self.signature = _get_signature(self.function)
+            return
+
+        vaa_validator = self._wrap_vaa()
+        if vaa_validator is None:
+            # vaa validator
+            self.validator = self.raw_validator
+            self.validate = self._explicit_validation
+            self.signature = val_signature
         else:
-            vaa_validator = self._wrap_vaa()
-            if vaa_validator is None:
-                # vaa validator
-                self.validator = self.raw_validator
-                self.signature = _get_signature(self.validator)
-                self.validate = self._explicit_validation
-            else:
-                # validator with the same signature as the function
-                self.validator = vaa_validator
-                if self.function is not None:
-                    self.signature = _get_signature(self.function)
-                self.validate = self._vaa_validation
+            # validator with the same signature as the function
+            self.validator = vaa_validator
+            self.validate = self._vaa_validation
+            if self.function is not None:
+                self.signature = _get_signature(self.function)
 
     def _init(self, args: Args, kwargs: Kwargs, exc=None) -> None:
         """

--- a/deal/_schemes.py
+++ b/deal/_schemes.py
@@ -15,11 +15,13 @@ class Scheme(ABC):
     The method should return True if the data is valid.
     Otherwise, it should set `errors` attribute and return False.
     """
+    __slots__ = ('data', 'errors')
     data: dict[str, Any]
     errors: list[vaa.Error]
 
     def __init__(self, data: dict[str, Any]) -> None:
         self.data = data
+        self.errors = []
 
     @abstractmethod
     def is_valid(self) -> bool:

--- a/deal/_schemes.py
+++ b/deal/_schemes.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
 
-import vaa
+
+if TYPE_CHECKING:
+    import vaa
 
 
-class Scheme:
+class Scheme(ABC):
     """A base class for implementing a custom validator.
 
     The custom validator should implement `is_valid` method.
@@ -18,5 +21,6 @@ class Scheme:
     def __init__(self, data: dict[str, Any]) -> None:
         self.data = data
 
+    @abstractmethod
     def is_valid(self) -> bool:
         raise NotImplementedError

--- a/deal/_source.py
+++ b/deal/_source.py
@@ -5,8 +5,6 @@ import tokenize
 from textwrap import dedent
 from typing import Callable, List
 
-from vaa._internal import Simple
-
 
 TokensType = List[tokenize.TokenInfo]
 processors = []
@@ -19,8 +17,6 @@ def processor(func: Callable[[TokensType], TokensType]) -> Callable[[TokensType]
 
 def get_validator_source(validator) -> str:
     # get source code
-    if isinstance(validator, Simple):
-        validator = validator.validator
     if not hasattr(validator, '__code__'):
         return ''
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers=[
 
 requires = [
     "astroid>=2.11.0",
-    "vaa>=0.2.1",
 ]
 
 [tool.flit.metadata.requires-extra]
@@ -34,6 +33,7 @@ all = [
     "hypothesis",
     "pygments",
     "typeguard",
+    "vaa>=0.2.1",
 ]
 test = [
     "coverage[toml]",
@@ -50,6 +50,7 @@ test = [
     "hypothesis",
     "pygments",
     "typeguard",
+    "vaa>=0.2.1",
 ]
 lint = [
     "flake8",

--- a/tests/test_runtime/test_inv.py
+++ b/tests/test_runtime/test_inv.py
@@ -14,6 +14,17 @@ def test_setting_object_attribute_fulfills_contract():
         a.x = -2
 
 
+def test_simple_signature():
+    @deal.inv(lambda _: _.x > 0)
+    class A:
+        x = 2
+
+    a = A()
+    a.x = 4
+    with pytest.raises(deal.InvContractError):
+        a.x = -2
+
+
 def test_setting_wrong_args_by_method_raises_error():
     @deal.inv(lambda obj: obj.x > 0)
     class A:


### PR DESCRIPTION
Most of vaa usage is for short signature. I doubt anyone really uses schemas. So, let's reimplement simple signature logic on deal side and make vaa optional.