### PR TITLE
Detect noqa comments

### DIFF
--- a/deal/linter/_checker.py
+++ b/deal/linter/_checker.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+import re
+import tokenize
 from typing import Iterator
 
 from astroid import AstroidSyntaxError
@@ -13,20 +15,48 @@ from ._rules import FuncRule, ModuleRule, rules
 from ._stub import StubsManager
 
 
+# based on regex from the source code of flake8
+RE_NOQA = re.compile(
+    r'# noqa(?::[\s]?(?P<codes>([A-Z]+[0-9]*(?:[,\s]+)?)+))?',
+    re.IGNORECASE,
+)
+RE_DIGITS = re.compile(r'[0-9]+')
+PREFIXES = ('DEAL', 'DEA1', 'DEL', 'DEA', 'DIL')
+
+
 class Checker:
-    __slots__ = ('_tree', '_filename', '_stubs')
+    """The entry point for the linter, compatible with flake8 plugins interface.
+    """
+    __slots__ = ('_tree', '_filename', '_tokens', '_stubs')
     name = 'deal'
     version = __version__
     _rules = rules
 
-    def __init__(self, tree: ast.Module, file_tokens=None, filename: str = 'stdin') -> None:
+    def __init__(
+        self,
+        tree: ast.Module,
+        file_tokens: list[tokenize.TokenInfo] | None = None,
+        filename: str = 'stdin',
+    ) -> None:
         self._tree = tree
         self._filename = filename
+        self._tokens = file_tokens
 
         paths = list(StubsManager.default_paths)
         if filename != 'stdin':
             paths.append(Path(filename).absolute().parent)
         self._stubs = StubsManager(paths=paths)
+
+    @classmethod
+    def from_path(cls, path: Path) -> Checker:
+        source = path.read_text()
+        with path.open('rb') as stream:
+            tokens = list(tokenize.tokenize(stream.readline))
+        return cls(
+            tree=ast.parse(source),
+            file_tokens=tokens,
+            filename=str(path),
+        )
 
     def run(self) -> Iterator[tuple]:
         for error in self.get_errors():
@@ -50,6 +80,9 @@ class Checker:
                     hs = hash(error)
                     if hs in reported:
                         continue
+                    noqa = self._get_noqa(error.row)
+                    if f'{error.code:03d}'.startswith(noqa):
+                        continue
                     reported.add(hs)
                     yield error
 
@@ -57,3 +90,34 @@ class Checker:
             if not isinstance(rule, ModuleRule):
                 continue
             yield from rule(tree=self._tree)
+
+    def _get_noqa(self, line_number: int) -> tuple[str, ...]:
+        """Extract codes defined in `noqa` comments (with DEAL prefix removed).
+        """
+        comment = self._get_comment(line_number)
+        if not comment:
+            return ()
+        match = RE_NOQA.search(comment)
+        if match is None:
+            return ()
+        raw_codes = (match.group('codes') or '').split(',')
+        clean_codes = []
+        for code in raw_codes:
+            code = code.strip().upper()
+            if not code.startswith(PREFIXES):
+                print(repr(code), match)
+                continue
+            match = RE_DIGITS.search(code)
+            clean_codes.append(match.group(0) if match else '')
+        return tuple(clean_codes)
+
+    def _get_comment(self, line_number: int) -> str | None:
+        if self._tokens is None:
+            return None
+        for token in self._tokens:
+            if token.start[0] != line_number:
+                continue
+            if token.type != tokenize.COMMENT:
+                continue
+            return token.string
+        return None

--- a/tests/test_linter/test_checker.py
+++ b/tests/test_linter/test_checker.py
@@ -2,6 +2,8 @@ import ast
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+
 from deal.linter import Checker
 
 
@@ -37,7 +39,7 @@ def test_stdin():
 def test_astroid_path(tmp_path: Path):
     path = tmp_path / 'test.py'
     path.write_text(TEXT)
-    checker = Checker(tree=ast.parse(TEXT), filename=str(path))
+    checker = Checker.from_path(path)
     errors = list(checker.run())
     assert errors == EXPECTED
 
@@ -56,11 +58,12 @@ def test_get_funcs_invalid_syntax(tmp_path: Path):
 
 
 def test_version():
-    version = Checker(tree=None, filename='stdin').version
+    version = Checker(tree=None, filename='stdin').version  # type: ignore[arg-type]
+    assert version.count('.') == 2
     assert not set(version) - set('0123456789.')
 
 
-def test_remove_duplicates(tmp_path):
+def test_remove_duplicates(tmp_path: Path):
     text = """
         import deal
 
@@ -74,6 +77,55 @@ def test_remove_duplicates(tmp_path):
     """
     path = tmp_path / 'test.py'
     path.write_text(dedent(text))
-    checker = Checker(tree=ast.parse(TEXT), filename=str(path))
+    checker = Checker.from_path(path)
     errors = list(checker.run())
     assert len(errors) == 1
+
+
+@pytest.mark.parametrize('comment, should_fail', [
+    ('', True),
+
+    # different prefix sizes
+    ('# noqa: DEAL021', False),
+    ('# noqa: DEAL02', False),
+    ('# noqa: DEAL0', False),
+    ('# noqa: DEAL', False),
+
+    # case insensitive
+    ('# NoQA: DEAL', False),
+    ('# NOQA: DEAL', False),
+    ('# noqa: deal', False),
+
+    # aliases
+    ('# noqa: DEA021', False),
+    ('# noqa: DEL021', False),
+    ('# noqa: DIL021', False),
+    ('# noqa: DEA0', False),
+    ('# noqa: DEA', False),
+
+    # mixed with other codes and garbage
+    ('# noqa: W13, DEAL021', False),
+    ('# noqa: DEAL021, W13', False),
+    ('# noqa: DEAL021 # nosec # type: ignore', False),
+    ('# nosec # type: ignore # noqa: DEAL021', False),
+
+    # not this noqa
+    ('# noqa: W13', True),
+    ('# noqa: DEAL022', True),
+    ('# noqa: D022', True),
+    ('# oh hi mark', True),
+    ('# type: ignore', True),
+    ('# nosec', True),
+])
+def test_noqa(tmp_path: Path, comment, should_fail):
+    text = f"""
+        import deal
+        @deal.safe
+        def f():
+            1/0 {comment}
+    """
+    path = tmp_path / 'test.py'
+    path.write_text(dedent(text))
+    checker = Checker.from_path(path)
+    errors = list(checker.run())
+    assert len(errors) == int(should_fail)


### PR DESCRIPTION
To keep backward compatibility when #119 is merged, handle `# noqa` comments on the deal side instead of trusting flake8 to do its job.