### PR TITLE
Specify maximum typeguard version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ integration = [  # integration tests
     "deal-solver",
     "hypothesis",
     "pygments",
-    "typeguard",
+    "typeguard<=2.13.3",
     "vaa>=0.2.1",
     "sphinx>=4.5.0",
     "flake8",


### PR DESCRIPTION
deal test doesn't work when typeguard>2.13.3 is installed. It gives an error like the following:
```
$ python3 -m deal test deal_test.py 
running deal_test.py
test
2
  running count
    count(item='', items=[])
    Traceback (most recent call last):
      File "/home/user/.local/lib/python3.9/site-packages/deal/_cli/_test.py", line 111, in run_cases
        case()
      File "/home/user/.local/lib/python3.9/site-packages/deal/_testing.py", line 55, in __call__
        self._check_result(result)
      File "/home/user/.local/lib/python3.9/site-packages/deal/_testing.py", line 65, in _check_result
        memo = typeguard._CallMemo(
      File "/home/user/.local/lib/python3.9/site-packages/typeguard/__init__.py", line 42, in __getattr__
        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
    AttributeError: module 'typeguard' has no attribute '_CallMemo'
```

"_CallMemo" seems to have been removed from typeguard.