### PR TITLE
Upgrade typeguard

### DIFF
--- a/deal/_testing.py
+++ b/deal/_testing.py
@@ -62,13 +62,14 @@ class TestCase(NamedTuple):
             import typeguard
         except ImportError:
             return
-        memo = typeguard._CallMemo(
-            func=self.func,
-            args=self.args,
-            kwargs=self.kwargs,
+        memo = typeguard.CallMemo(
+            func=self.func,  # type: ignore[arg-type]
+            frame_locals=self.kwargs,
         )
-        typeguard.check_argument_types(memo=memo)
-        typeguard.check_return_type(result, memo=memo)
+        from typeguard._functions import check_return_type
+
+        # check_argument_types(memo=memo)
+        check_return_type(result, memo=memo)
 
 
 class cases:  # noqa: N

--- a/deal/_testing.py
+++ b/deal/_testing.py
@@ -66,9 +66,10 @@ class TestCase(NamedTuple):
             func=self.func,  # type: ignore[arg-type]
             frame_locals=self.kwargs,
         )
-        from typeguard._functions import check_return_type
+        from typeguard._functions import check_argument_types, check_return_type
 
-        # check_argument_types(memo=memo)
+        if not self.args and self.kwargs:
+            check_argument_types(memo=memo)
         check_return_type(result, memo=memo)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ all = [
     "deal-solver",
     "hypothesis",
     "pygments",
-    "typeguard",
+    "typeguard>=3.0.0",
     "vaa>=0.2.1",
 ]
 integration = [  # integration tests
@@ -37,7 +37,7 @@ integration = [  # integration tests
     "deal-solver",
     "hypothesis",
     "pygments",
-    "typeguard<=2.13.3",
+    "typeguard",
     "vaa>=0.2.1",
     "sphinx>=4.5.0",
     "flake8",

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -182,6 +182,22 @@ def test_return_type():
 
 
 @pytest.mark.skipif(hypothesis is None, reason='hypothesis is not installed')
+@pytest.mark.skipif(typeguard is None, reason='typeguard is not installed')
+def test_typecheck_explicit_kwargs():
+    def identity(a: int) -> str:
+        return 'ok'
+
+    kwargs: dict = dict(args=(), func=identity, exceptions=(), check_types=True)
+    case = deal.TestCase(kwargs={'a': 13}, **kwargs)
+    case()
+
+    case = deal.TestCase(kwargs={'a': 'hi'}, **kwargs)
+    msg = re.escape('argument "a" (str) is not an instance of int')
+    with pytest.raises(typeguard.TypeCheckError, match=msg):
+        case()
+
+
+@pytest.mark.skipif(hypothesis is None, reason='hypothesis is not installed')
 def test_type_var():
     T = TypeVar('T')  # noqa: N806
 


### PR DESCRIPTION
A new version of [typeguard](https://github.com/agronholm/typeguard) is here, and its low-level API is different. See #125.

The PR upgrades deal to work with the new version of typeguard. The minimal supported version now is 3.0.0.

Minor change: if you explicitly pass positional arguments into `deal.case`, they are not type checked anymore.