### PR TITLE
Added Typing to decorator validators

### DIFF
--- a/deal/_runtime/_decorators.py
+++ b/deal/_runtime/_decorators.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 def pre(
-    validator,
+    validator: Callable[..., bool],
     *,
     message: str | None = None,
     exception: ExceptionType | None = None,
@@ -66,7 +66,7 @@ def pre(
 
 
 def post(
-    validator,
+    validator: Callable[..., bool],
     *,
     message: str | None = None,
     exception: ExceptionType | None = None,
@@ -111,7 +111,7 @@ def post(
 
 
 def ensure(
-    validator,
+    validator: Callable[..., bool],
     *,
     message: str | None = None,
     exception: ExceptionType | None = None,
@@ -253,7 +253,7 @@ def has(
 
 def reason(
     event: type[Exception],
-    validator,
+    validator: Callable[..., bool],
     *,
     message: str | None = None,
     exception: ExceptionType | None = None,
@@ -307,7 +307,7 @@ def reason(
 
 
 def inv(
-    validator,
+    validator: Callable[..., bool],
     *,
     message: str | None = None,
     exception: ExceptionType | None = None,


### PR DESCRIPTION
Hi Orsinium (and team)

As I was testing contract, Pylance was giving me type errors due to validator not being typed.

Before typing:
<img width="357" alt="Screenshot 2024-03-24 at 12 35 22 PM" src="https://github.com/life4/deal/assets/2172753/b070a0e6-7f39-42a3-b25b-4d1f8fb9a4cd">

This is not such a nice DX for first-time users using strict typing, so I wanted to fix it.

I think the output of a validator is always supposed to be bool, making this a simple fix.

After typing:
<img width="379" alt="Screenshot 2024-03-24 at 12 35 34 PM" src="https://github.com/life4/deal/assets/2172753/68e5d5bf-3a61-4faa-9cb5-2517d828d946">