### PR TITLE
Improve Type Safety and fix mypy errors

### DIFF
--- a/deal/_runtime/_decorators.py
+++ b/deal/_runtime/_decorators.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Callable, TypeVar, overload
+from typing import Callable, TypeVar, cast, overload
 
 from .. import _exceptions
 from .._types import ExceptionType
@@ -13,11 +13,10 @@ from ._invariant import invariant
 from ._validators import InvariantValidator, RaisesValidator, ReasonValidator, Validator
 
 
-if TYPE_CHECKING:
-    C = TypeVar('C', bound=Callable)
-    F = TypeVar('F', bound=Callable)
-    T = TypeVar('T')
-    TF = TypeVar('TF', bound='Callable | type')
+C = TypeVar('C', bound=Callable)
+F = TypeVar('F', bound=Callable)
+T = TypeVar('T')
+TF = TypeVar('TF', bound='Callable | type')
 
 
 def pre(
@@ -61,7 +60,7 @@ def pre(
         message=message,
         exception=exception or _exceptions.PreContractError,
     )
-    func = partial(Contracts.attach, 'pres', contract)
+    func = cast(Callable[[C], C], partial(Contracts.attach, 'pres', contract))
     return func
 
 
@@ -106,7 +105,7 @@ def post(
         message=message,
         exception=exception or _exceptions.PostContractError,
     )
-    func = partial(Contracts.attach, 'posts', contract)
+    func = cast(Callable[[C], C], partial(Contracts.attach, 'posts', contract))
     return func
 
 
@@ -155,7 +154,7 @@ def ensure(
         exception=exception or _exceptions.PostContractError,
     )
     func = partial(Contracts.attach, 'ensures', contract)
-    return func
+    return cast(Callable[[C], C], func)
 
 
 def raises(
@@ -204,7 +203,7 @@ def raises(
         exception=exception or _exceptions.RaisesContractError,
     )
     func = partial(Contracts.attach, 'raises', contract)
-    return func
+    return cast(Callable[[C], C], func)
 
 
 def has(
@@ -248,7 +247,7 @@ def has(
         exception=exception,
     )
     func = partial(Contracts.attach_has, patcher)
-    return func
+    return cast(Callable[[C], C], func)
 
 
 def reason(
@@ -303,7 +302,7 @@ def reason(
         exception=exception or _exceptions.ReasonContractError,
     )
     func = partial(Contracts.attach, 'reasons', contract)
-    return func
+    return cast(Callable[[C], C], func)
 
 
 def inv(
@@ -367,7 +366,7 @@ def inv(
         message=message,
         exception=exception or _exceptions.InvContractError,
     )
-    return partial(invariant, contract)
+    return cast(Callable[[T], T], partial(invariant, contract))
 
 
 def example(validator: Callable[[], bool]) -> Callable[[C], C]:
@@ -393,7 +392,7 @@ def example(validator: Callable[[], bool]) -> Callable[[C], C]:
         message=None,
         exception=_exceptions.ExampleContractError,
     )
-    func = partial(Contracts.attach, 'examples', contract)
+    func = cast(Callable[[C], C], partial(Contracts.attach, 'examples', contract))
     return func
 
 

--- a/deal/introspection/_extractor.py
+++ b/deal/introspection/_extractor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Callable, Iterator, TypeVar
+from typing import Callable, Iterator, Protocol, TypeVar
+
+from typing_extensions import TypeGuard
 
 from .._runtime import Contracts, Inherit
 from . import _wrappers
@@ -9,6 +11,14 @@ from ._wrappers import Contract, ValidatedContract
 
 ATTR = '__deal_contract'
 F = TypeVar('F', bound=Callable)
+
+
+class WithWrappedSpecial(Protocol):
+    __wrapped__: Callable
+
+
+def has_wrapped(cobj: Callable) -> TypeGuard[WithWrappedSpecial]:
+    return hasattr(cobj, '__wrapped__')
 
 
 def unwrap(func: F) -> F:
@@ -52,6 +62,6 @@ def get_contracts(func: Callable) -> Iterator[Contract]:
             if contracts.patcher:
                 yield _wrappers.Has(contracts.patcher)
 
-        if not hasattr(func, '__wrapped__'):
+        if not has_wrapped(func):
             return
         func = func.__wrapped__

--- a/deal/linter/_contract.py
+++ b/deal/linter/_contract.py
@@ -162,8 +162,7 @@ class Contract:
         # inject function signature
         func = ast.Lambda(
             args=self.func_args,
-            body=ast.Set(elts=[], ctx=ast.Load()),
-            ctx=ast.Load(),
+            body=ast.Set(elts=[]),
         )
         module.body[FUNC_INDEX].value = func  # type: ignore
 
@@ -198,7 +197,6 @@ class Contract:
             body = list(deps)
             return_node = ast.Return(
                 value=contract.body,
-                ctx=ast.Load(),
             )
             body.append(return_node)
             module.body[CONTRACT_INDEX] = ast.FunctionDef(
@@ -206,7 +204,6 @@ class Contract:
                 args=contract.args,
                 body=body,
                 decorator_list=[],
-                ctx=ast.Load(),
             )
             return module
 

--- a/deal/linter/_extractors/definitions.py
+++ b/deal/linter/_extractors/definitions.py
@@ -29,7 +29,6 @@ def _extract_defs_ast(tree: ast.Module) -> DefsType:
                     names=[name_node],
                     lineno=1,
                     col_offset=1,
-                    ctx=ast.Load(),
                 )
             continue
 
@@ -41,9 +40,9 @@ def _extract_defs_ast(tree: ast.Module) -> DefsType:
                 result[name] = ast.ImportFrom(
                     module=node.module,
                     names=[name_node],
+                    level=0,
                     lineno=1,
                     col_offset=1,
-                    ctx=ast.Load(),
                 )
             continue
 
@@ -64,7 +63,6 @@ def _extract_defs_astroid(tree: astroid.Module) -> DefsType:
                     names=[ast.alias(name=name, asname=alias)],
                     lineno=1,
                     col_offset=1,
-                    ctx=ast.Load(),
                 )
             continue
 
@@ -75,9 +73,9 @@ def _extract_defs_astroid(tree: astroid.Module) -> DefsType:
                 result[alias or name] = ast.ImportFrom(
                     module=node.modname,
                     names=[ast.alias(name=name, asname=alias)],
+                    level=0,
                     lineno=1,
                     col_offset=1,
-                    ctx=ast.Load(),
                 )
             continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,12 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
 ]
+dependencies = ["typing_extensions>=4.12.2"]
 
 [project.urls]
 Repository = "https://github.com/life4/deal"
 Documentation = "https://deal.readthedocs.io/"
+
 
 [project.optional-dependencies]
 all = [


### PR DESCRIPTION
# Description

## Type System Improvements

1) Added TypeGuard for safer runtime type narrowing:
- New has_wrapped function to safely check for - `__wrapped__` attribute
New `has_location` function to verify AST node attributes

2) Introduced Protocol classes for better interface definitions:

- `WithWrappedSpecial` for wrapped function handling
- `LocationProvider` for AST node location information

3) Implemented proper return type casting for decorators using `typing.cast`

4) Removed redundant `ctx=ast.Load()` parameters from AST node construction
5) Added missing level=0 parameter to `ImportFrom` nodes
6) Simplified `AST` node creation where context was unnecessary

## Dependencies

Added `typing_extensions>=4.12.2` as a required dependency to support new typing features

## Testing

- Existing tests should cover the refactored code as this is primarily a type system improvement
- No new runtime behavior has been introduced
- Static type checking (mypy/pyright) should show improved type safety