### PR TITLE
Python 3.12.9 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          # - "3.12"
+          - "3.12"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -23,8 +23,9 @@ def test_unknown_command(capsys):
     result = main(argv=['unknown', 'a1', 'a2'], commands=dict(fake=FakeCommand))
     assert result == 2
     captured = capsys.readouterr()
-    exp = "invalid choice: 'unknown' (choose from fake)"
-    assert exp in captured.err
+    exp1 = "invalid choice: 'unknown' (choose from fake)"
+    exp2 = "invalid choice: 'unknown' (choose from 'fake')"
+    assert exp1 in captured.err or exp2 in captured.err
 
 
 def test_no_command_specified(capsys):

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -23,7 +23,7 @@ def test_unknown_command(capsys):
     result = main(argv=['unknown', 'a1', 'a2'], commands=dict(fake=FakeCommand))
     assert result == 2
     captured = capsys.readouterr()
-    exp = "invalid choice: 'unknown' (choose from 'fake')"
+    exp = "invalid choice: 'unknown' (choose from fake)"
     assert exp in captured.err
 
 


### PR DESCRIPTION
Failing test:

```
    def test_unknown_command(capsys):
        result = main(argv=['unknown', 'a1', 'a2'], commands=dict(fake=FakeCommand))
        assert result == 2
        captured = capsys.readouterr()
        exp = "invalid choice: 'unknown' (choose from 'fake')"
>       assert exp in captured.err
E       assert "invalid choice: 'unknown' (choose from 'fake')" in "usage: python3 -m deal [-h] {fake} ...\npython3 -m deal: error: argument {fake}: invalid choice: 'unknown' (choose from fake)\n"
E        +  where "usage: python3 -m deal [-h] {fake} ...\npython3 -m deal: error: argument {fake}: invalid choice: 'unknown' (choose from fake)\n" = CaptureResult(out='', err="usage: python3 -m deal [-h] {fake} ...\npython3 -m deal: error: argument {fake}: invalid choice: 'unknown' (choose from fake)\n").err

tests/test_cli/test_main.py:27: AssertionError
```

Even though [argparse's documentation](https://docs.python.org/3/library/argparse.html#choices) specifies that it single-quotes the choices, it actually doesn't, [according to their own tests](https://github.com/python/cpython/blob/c9932a9ec8a3077933a85101aae9c3ac155e6d04/Lib/test/test_argparse.py#L1020).